### PR TITLE
Do not depend on log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = { version = "0.70", default-features = false }
 cc = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
As the title says, do not pull in bindgen's optional dependency on the log crate.