### PR TITLE
Create node.js plugin; update ABI to v1.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,19 @@
+{
+    "targets": [
+        {
+            "target_name": "customlabels",
+            "sources": [
+                "js/addon.c",
+                "js/addon_node.c",
+                "src/customlabels.c"
+            ],
+            "cflags": [
+                "-ftls-model=global-dynamic",
+                "-mtls-dialect=desc",
+                "-fPIC",
+                "-O3",
+                "-g"
+            ]
+        }
+    ]
+}

--- a/custom-labels-v1.md
+++ b/custom-labels-v1.md
@@ -1,4 +1,4 @@
-# Custom Label ABI (v0)
+# Custom Label ABI (v1)
 
 ## Description
 
@@ -16,15 +16,15 @@ The process must be running on Linux on an x86-64 or aarch64 system.
 
 Two pieces of data must be exposed by the process; they are described in detail below. The component that defines this data must be an ELF binary loaded on startup by the process (that is, either the main executable or a dynamically linked library in the initial set loaded on startup).
 
-If the binary is a dynamically linked library, its filename must match the following regular expression: `libcustomlabels.*\.so`.
+If the binary is a dynamically linked library, its filename must match the following regular expression: `libcustomlabels.*\.so$|customlabels\.node$`.
 
 ## `custom_labels_abi_version`
 
-The binary must export a dynamic symbol called `custom_labels_abi_version`. It must be have a size of 4 bytes and have the constant value `0`.
+The binary must export a dynamic symbol called `custom_labels_abi_version`. It must be have a size of 4 bytes and have the constant value `1`.
 
-## `custom_labels_thread_local_data`
+## `custom_labels_current_set`
 
-The binary must export a dynamic symbol called `custom_labels_thread_local_data`.
+The binary must export a dynamic symbol called `custom_labels_current_set`.
 
 If the binary is the main executable, the object must be accessible from the statically known offset from the thread pointer described in ["ELF Handing For Thread-Local Storage"](https://www.akkadia.org/drepper/tls.pdf) (variant I for aarch64; variant II for x86-64).
 
@@ -45,7 +45,7 @@ or as follows on aarch64:
 gcc -ftls-model=global-dynamic -mtls-dialect=desc -fPIC -shared -o libcustomlabels.so customlabels.c
 ```
 
-The object referenced by this symbol must have the layout of `tls_t`, defined as follows:
+The object referenced by this symbol must be a pointer to a structure that has the layout of `custom_labels_labelset_t`, defined as follows:
 
 ``` c
 typedef struct {
@@ -61,17 +61,18 @@ typedef struct {
 typedef struct {
         custom_labels_label_t *storage;
         size_t count;
-} tls_t;
+        size_t capacity;
+} custom_labels_labelset_t;
 ```
 
 ## Interpretation of data
 
-As already stated, `custom_labels_abi_version` has the constant value `0`. If it has any other value, nothing in this document applies. 
+As already stated, `custom_labels_abi_version` has the constant value `1`. If it has any other value, nothing in this document applies. 
 
-While a the thread is suspended, the external program may determine its active label set by reading the data at `custom_labels_thread_local_data` according to the following principles.
+While a the thread is suspended, the external program may determine its active label set by reading the data pointed to by `custom_labels_current_set` according to the following principles.
 
 * `custom_labels_string_t`: if `buf` is null, this represents the absence of a value. Otherwise, `buf` points to an array of bytes of size `len`.
 * `custom_labels_label_t`: if `key.buf` represents the absence of a value (that is, if `key.buf` is null), this object is ignored. `val.buf` must never be null. Otherwise, this represents a label whose key is `key` and whose value is `value`.
-* `tls_t`: `storage` points to an array of possible labels of length `count`. As described above, an element of `storage` whose key is absent is ignored. An element is also ignored if its key is identical to an element that appears earlier in the array. Thus `tls_t` represents a label set where uniqueness of keys is guaranteed by taking the first label for any given key.
+* `custom_labels_labelset_t`: `storage` points to an array of possible labels of length `count`. As described above, an element of `storage` whose key is absent is ignored. An element is also ignored if its key is identical to an element that appears earlier in the array. Thus `custom_labels_labelset_t` represents a label set where uniqueness of keys is guaranteed by taking the first label for any given key. The value of `capacity` is used internally by the library and has no meaning to profilers.
 
 **Note**: Label sets are indeed mathematical _sets_; that is, they are unordered. Thus order of the objects in `tls_t::storage` has no meaning except for disambiguation of keys as described above.

--- a/dlist
+++ b/dlist
@@ -6,5 +6,5 @@
  */
 {
   custom_labels_abi_version;
-  custom_labels_thread_local_data;
+  custom_labels_current_set;
 };

--- a/js/addon.c
+++ b/js/addon.c
@@ -1,0 +1,310 @@
+// addon.c
+#include "addon.h"
+#include "js_native_api.h"
+#include "../src/customlabels.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#define NODE_API_CALL(env, call)                                  \
+  do {                                                            \
+    napi_status status = (call);                                  \
+    if (status != napi_ok) {                                      \
+      const napi_extended_error_info* error_info = NULL;          \
+      napi_get_last_error_info((env), &error_info);               \
+      const char* err_message = error_info->error_message;        \
+      bool is_pending;                                            \
+      napi_is_exception_pending((env), &is_pending);              \
+      /* If an exception is already pending, don't rethrow it */  \
+      if (!is_pending) {                                          \
+        const char* message = (err_message == NULL)               \
+            ? "empty error message"                               \
+            : err_message;                                        \
+        napi_throw_error((env), NULL, message);                   \
+      }                                                           \
+      return NULL;                                                \
+    }                                                             \
+  } while(0)
+
+struct ref_counted_labelset {
+  custom_labels_labelset_t *native;
+  unsigned n_refs;
+};
+
+struct labelset_ref {
+  struct ref_counted_labelset *target;
+};
+
+void LabelSetRefFz(napi_env env, void *finalize_data, void *finalize_hint) {
+  struct labelset_ref *ref = (struct labelset_ref *)finalize_data;
+  if (!--ref->target->n_refs) {
+    custom_labels_labelset_free(ref->target->native);
+    free(ref->target);
+  }  
+  free(ref);
+}
+
+static napi_ref labelset_ref_ctor_ref = NULL;
+
+static napi_value LabelSetRefCtor(napi_env env, napi_callback_info info) {
+  napi_value this;
+  size_t argc = 1;
+  napi_value arg = NULL;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &arg, &this, NULL));
+  
+  bool isinstance;
+  napi_value ctor;
+  NODE_API_CALL(env, napi_get_reference_value(env, labelset_ref_ctor_ref, &ctor));
+  NODE_API_CALL(env, napi_instanceof(env, this, ctor, &isinstance));
+  if (!isinstance) {
+    napi_throw_error(env, NULL, "Must be called with 'new'");
+    return NULL;
+  }
+
+  struct ref_counted_labelset *target = NULL;
+  if (argc > 0) {
+    struct labelset_ref *parent = NULL;
+    NODE_API_CALL(env, napi_instanceof(env, arg, ctor, &isinstance));
+    if (!isinstance) {
+      napi_throw_error(env, NULL, "arg must be of type LabelSetRef");
+      return NULL;
+    }
+    NODE_API_CALL(env, napi_unwrap(env, arg, (void **)&parent));
+    target = parent->target;
+  }
+  if (!target) {
+    target = (struct ref_counted_labelset *)malloc(sizeof(struct ref_counted_labelset));
+    if (!target) {
+      napi_throw_error(env, NULL, "allocation failed!");
+      return NULL;
+    }
+    target->n_refs = 0;
+    target->native = custom_labels_labelset_new(0);
+    if (!target->native) {
+      napi_throw_error(env, NULL, "allocation failed!");
+      free(target);
+      return NULL;
+    }
+  }
+  struct labelset_ref *ref = malloc(sizeof(struct labelset_ref));
+  if (!ref) {
+    if (target->n_refs == 0) {
+      custom_labels_labelset_free(target->native);
+      free(target);
+    }
+    napi_throw_error(env, NULL, "allocation failed!");
+    return NULL;
+  }
+  ref->target = target;
+  ++target->n_refs;
+  
+  NODE_API_CALL(env, napi_wrap(env, this, ref, LabelSetRefFz, NULL, NULL));
+
+  return this;
+}
+
+static int
+setOrDeleteValue(napi_env env, struct labelset_ref *ref, custom_labels_string_t key, custom_labels_string_t value) {
+  assert(ref->target->n_refs > 0);
+  // if there are other references to this label set, we need
+  // to clone it here, so they don't get clobbered.
+  bool should_clone = (ref->target->n_refs != 1);
+  // if the given set is already installed, and we're about to clone it,
+  // we need to install the new one after.
+  bool must_install = (ref->target->native == custom_labels_current_set) && should_clone;
+  struct ref_counted_labelset *old_target = NULL;
+  if (should_clone) {
+    --ref->target->n_refs;
+    custom_labels_labelset_t *new_native = custom_labels_labelset_clone(ref->target->native);
+    if (!new_native) {
+      napi_throw_error(env, NULL, "allocation failed!");
+      return errno;
+    }
+    old_target = ref->target;
+    struct ref_counted_labelset *new_target = malloc(sizeof(struct ref_counted_labelset));
+    if (!new_target) {
+      custom_labels_labelset_free(new_native);
+      napi_throw_error(env, NULL, "allocation failed!");
+      return errno;
+    }
+    new_target->native = new_native;
+    new_target->n_refs = 1;
+    ref->target = new_target;
+  }
+  assert(should_clone == (bool)old_target);
+  if (value.buf) {
+    int err = custom_labels_labelset_set(ref->target->native, key, value);
+    if (err) {
+      // if we cloned, let's get rid of the clone and put back the old target.
+      if (should_clone) {
+        custom_labels_labelset_free(ref->target->native);
+        free(ref->target);
+        ref->target = old_target;
+        ++ref->target->n_refs;
+      }
+      napi_throw_error(env, NULL, "allocation failed!");
+      return err;
+    }
+  }
+  else {
+    custom_labels_labelset_delete(ref->target->native, key);
+  }
+  if (must_install) {
+    custom_labels_labelset_replace(ref->target->native);
+  }
+  return 0;
+}
+
+#define THISCHK()                                                       \
+  do {                                                                  \
+    bool isinstance;                                                    \
+    napi_value ctor;                                                    \
+    NODE_API_CALL(env, napi_get_reference_value(env, labelset_ref_ctor_ref, &ctor)); \
+    NODE_API_CALL(env, napi_instanceof(env, this, ctor, &isinstance));  \
+    if (!isinstance) {                                                  \
+      napi_throw_error(env, NULL, "this must be of type LabelSetRef");  \
+      return NULL;                                                      \
+    }                                                                   \
+  } while (0)
+
+// setValue(k, v)
+// clones the underlying LS if there are other references to it,
+// to avoid clobbering those. Otherwise, if we own it exclusively,
+// just updates the value.
+static napi_value
+LabelSetSetValue(napi_env env, napi_callback_info info) {
+  // XXX error handling (in entire file)
+  napi_value this;
+  size_t argc = 2;
+  napi_value argv[2];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, &this, NULL));
+  THISCHK();
+  if (argc != 2) {
+    napi_throw_error(env, NULL, "setValue(k, v)");
+    return NULL;
+  }  
+  
+  char kbuf[64 + 1]; // +1 for null terminator
+  size_t klen;
+  char vbuf[64 + 1];
+  size_t vlen;
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, argv[0], kbuf, sizeof(kbuf), &klen));
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, argv[1], vbuf, sizeof(vbuf), &vlen));
+
+  struct labelset_ref *ref;
+  NODE_API_CALL(env, napi_unwrap(env, this, (void **)&ref));
+  // if the given set is already installed, and we're about to clone it,
+  // we need to install the new one after.
+  int err = setOrDeleteValue(env, ref, (custom_labels_string_t){klen, (unsigned char *)kbuf }, (custom_labels_string_t){vlen, (unsigned char *)vbuf});
+  if (err) {
+    napi_throw_error(env, NULL, "failed to set value");    
+  }
+  return NULL;
+}
+
+static napi_value
+LabelSetGetValue(napi_env env, napi_callback_info info) {
+  napi_value this;
+  size_t argc = 1;
+  napi_value argv[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, &this, NULL));
+  THISCHK();
+  if (argc != 1) {
+    napi_throw_error(env, NULL, "getValue(k)");
+    return NULL;
+  }
+  struct labelset_ref *ref;
+  NODE_API_CALL(env, napi_unwrap(env, this, (void **)&ref));
+
+  char kbuf[64 + 1]; // +1 for null terminator
+  size_t klen;
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, argv[0], kbuf, sizeof(kbuf), &klen));
+  const custom_labels_label_t *lbl = custom_labels_labelset_get(ref->target->native, (custom_labels_string_t){klen, (unsigned char *)kbuf});
+  if (!lbl)
+    return NULL;
+
+  napi_value result;
+  NODE_API_CALL(env, napi_create_string_utf8(env, (const char *)lbl->value.buf, lbl->value.len, &result));
+  return result;
+}
+
+static napi_value
+LabelSetDeleteValue(napi_env env, napi_callback_info info) {
+  napi_value this;
+  size_t argc = 1;
+  napi_value argv[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, &this, NULL));
+  THISCHK();
+  if (argc != 1) {
+    napi_throw_error(env, NULL, "deleteValue(k)");
+    return NULL;
+  }
+  struct labelset_ref *ref;
+  NODE_API_CALL(env, napi_unwrap(env, this, (void **)&ref));
+
+  char kbuf[64 + 1]; // +1 for null terminator
+  size_t klen;
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, argv[0], kbuf, sizeof(kbuf), &klen));
+
+  int err = setOrDeleteValue(env, ref, (custom_labels_string_t){klen, (unsigned char *)kbuf}, (custom_labels_string_t) { 0, NULL});
+  if (err) {
+    napi_throw_error(env, NULL, "failed to delete value");
+  }    
+
+  return NULL;
+}
+
+static napi_value
+LabelSetInstall(napi_env env, napi_callback_info info) {
+  napi_value this;
+  NODE_API_CALL(env, napi_get_cb_info(env, info, NULL, NULL, &this, NULL));
+  struct labelset_ref *ref;
+  NODE_API_CALL(env, napi_unwrap(env, this, (void **)&ref));
+
+  custom_labels_labelset_replace(ref->target->native);
+  return NULL;
+}
+
+napi_value ClearLabelSet(napi_env env, napi_callback_info info) {
+  custom_labels_labelset_replace(NULL);
+  return NULL;
+}
+
+
+napi_value create_addon(napi_env env) {
+  napi_value result;
+  NODE_API_CALL(env, napi_create_object(env, &result));
+
+  napi_value clear_label_set_function;
+  NODE_API_CALL(env, napi_create_function(env,
+                                          "clearLabelSet",
+                                          NAPI_AUTO_LENGTH,
+                                          ClearLabelSet,
+                                          NULL,
+                                          &clear_label_set_function));
+
+  NODE_API_CALL(env, napi_set_named_property(env,
+                                             result,
+                                             "clearLabelSet",
+                                             clear_label_set_function));
+  
+  napi_value labelset_ref;
+
+  napi_property_descriptor properties[] = {
+    { "setValue", NULL, LabelSetSetValue, NULL, NULL, NULL, napi_default, NULL },
+    { "getValue", NULL, LabelSetGetValue, NULL, NULL, NULL, napi_default, NULL },
+    { "deleteValue", NULL, LabelSetDeleteValue, NULL, NULL, NULL, napi_default, NULL },
+    { "install", NULL, LabelSetInstall, NULL, NULL, NULL, napi_default, NULL },
+  };
+  
+  NODE_API_CALL(env, napi_define_class(env, "LabelSetRef", NAPI_AUTO_LENGTH, LabelSetRefCtor,
+                                       NULL, sizeof(properties)/sizeof(properties[0]), properties, &labelset_ref));
+
+  NODE_API_CALL(env, napi_create_reference(env, labelset_ref, 1, &labelset_ref_ctor_ref));
+
+  NODE_API_CALL(env, napi_set_named_property(env, result, "LabelSetRef", labelset_ref));
+                                       
+  
+  return result;
+}

--- a/js/addon.h
+++ b/js/addon.h
@@ -1,0 +1,7 @@
+// addon.h
+#ifndef _ADDON_H_
+#define _ADDON_H_
+#include <js_native_api.h>
+napi_value create_addon(napi_env env);
+#endif  // _ADDON_H_
+

--- a/js/addon_node.c
+++ b/js/addon_node.c
@@ -1,0 +1,10 @@
+// addon_node.c
+#include <node_api.h>
+#include "addon.h"
+
+NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
+  // This function body is expected to return a `napi_value`.
+  // The variables `napi_env env` and `napi_value exports` may be used within
+  // the body, as they are provided by the definition of `NAPI_MODULE_INIT()`.
+  return create_addon(env);
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,61 @@
+const bindings = require('bindings');
+
+const addon = bindings('customlabels');
+
+const { createHook, executionAsyncId, AsyncResource } = require( 'node:async_hooks');
+const { writeSync }  = require( 'fs');
+const { inspect }  = require( 'util');
+
+const begin = Date.now();
+
+const lsByAsyncId = new Map();
+
+const h = createHook({
+    init(asyncId, type, triggerAsyncId, resource) {
+        const parent = lsByAsyncId.get(triggerAsyncId);
+        if (parent) {
+            lsByAsyncId.set(asyncId, new addon.LabelSetRef(parent));
+        } else {
+            lsByAsyncId.set(asyncId, new addon.LabelSetRef());
+        }
+    },
+    before(asyncId) {
+        const x = lsByAsyncId.get(asyncId);
+        if (x) {
+            x.install();
+        }
+    },
+    after(asyncId) {
+        const x = lsByAsyncId.get(executionAsyncId());
+        if (x) {
+            x.install();
+        } else {
+            addon.clearLabelSet();
+        }
+    },
+    destroy(asyncId) {
+        lsByAsyncId.delete(asyncId);
+    },   
+});
+
+h.enable();
+
+exports.withLabel = function(k, v, f) {
+    let ls = lsByAsyncId.get(executionAsyncId());
+    if (!ls) {
+        ls = new addon.LabelSetRef();
+        lsByAsyncId.set(executionAsyncId, ls);
+        ls.install();
+    }
+    const old = ls.getValue(k);
+    ls.setValue(k, v);
+    f();
+    if (old) {
+        ls.setValue(k, old);
+    } else {
+        ls.deleteValue(k);
+    }
+};
+
+
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "custom-labels",
+    "version": "1.0.4",
+    "description": "test",
+    "main": "js/index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "install": "node-gyp rebuild"
+    },
+    "author": "",
+    "license": "ISC",
+    "gypfile": true,
+    "type": "cjs",
+    "files": ["js/*.c", "js/*.h", "js/*.js", "src/*.h", "src/*.c", "binding.gyp"],
+    "dependencies": {
+        "bindings": "^1.5.0"
+    }
+}

--- a/src/customlabels.c
+++ b/src/customlabels.c
@@ -24,61 +24,74 @@
 #define MAX(a,b) ((a) > (b) ? (a) : (b))
 
 __attribute__((retain))
-const uint32_t custom_labels_abi_version = 0;
+const uint32_t custom_labels_abi_version = 1;
 
-typedef struct {
+struct _custom_labels_ls {
   custom_labels_label_t *storage;
   size_t count;
-} tls;
+  size_t capacity;
+};
 
 __attribute__((retain))
-__thread tls custom_labels_thread_local_data = (tls) { NULL, 0 };
+__thread custom_labels_labelset_t *custom_labels_current_set = NULL;
 
-#define tls_count (custom_labels_thread_local_data.count)
-#define tls_storage (custom_labels_thread_local_data.storage)
+/* thread_local_data = (tls) { NULL, 0 }; */
 
-static __thread size_t capacity = 0;
+/* #define tls_count (custom_labels_thread_local_data.count) */
+/* #define tls_storage (custom_labels_thread_local_data.storage) */
+
+#define cur_count (custom_labels_current_set->count)
+#define cur_storage (custom_labels_current_set->storage)
+#define cur_capacity (custom_labels_current_set->capacity)
 
 static bool eq(custom_labels_string_t l, custom_labels_string_t r) {
         return l.len == r.len &&
                 !memcmp(l.buf, r.buf, l.len);
 }
 
-static custom_labels_label_t *custom_labels_get_mut(custom_labels_string_t key) {
-        for (size_t i = 0; i < tls_count; ++i) {
-                if (!tls_storage[i].key.buf) {
+static custom_labels_label_t *labelset_get_mut(custom_labels_labelset_t *ls, custom_labels_string_t key) {
+        for (size_t i = 0; i < ls->count; ++i) {
+                if (!ls->storage[i].key.buf) {
                         continue;
                 }
-                if (eq(tls_storage[i].key, key)) {
-                        return &tls_storage[i];
+                if (eq(ls->storage[i].key, key)) {
+                        return &ls->storage[i];
                 }
         }
         return NULL;
 }
 
-const custom_labels_label_t *custom_labels_get(custom_labels_string_t key) {
-        return custom_labels_get_mut(key);
+static custom_labels_label_t *get_mut(custom_labels_string_t key) {
+        if (!custom_labels_current_set)
+                return NULL;
+        return labelset_get_mut(custom_labels_current_set, key);
 }
 
-// `push` pushes a new element onto the thread-local vector of labels.
+const custom_labels_label_t *custom_labels_get(custom_labels_string_t key) {
+        return get_mut(key);
+}
+
+// `push` pushes a new element onto the current set's vector of labels.
 // `key` must not be the same as any existing label's key, which must
 // be checked by the caller.
 static int push(custom_labels_string_t key, custom_labels_string_t value) {
-        if (tls_count == capacity) {
-                size_t new_cap = MAX(2 * capacity, 1);
+        if (!custom_labels_current_set)
+                return EFAULT;
+        if (cur_count == cur_capacity) {
+                size_t new_cap = MAX(2 * cur_capacity, 1);
                 custom_labels_label_t *new_storage = malloc(sizeof(custom_labels_label_t) * new_cap);
                 if (!new_storage) {
                         return errno;
                 }
-                memcpy(new_storage, tls_storage, sizeof(custom_labels_label_t) * tls_count);
-                custom_labels_label_t *old_storage = tls_storage;
+                memcpy(new_storage, cur_storage, sizeof(custom_labels_label_t) * cur_count);
+                custom_labels_label_t *old_storage = cur_storage;
                 // Need barriers on both sides because we have to prepare
                 // the new storage, then point to it, then free the old storage,
                 // in that order.
                 BARRIER;
-                tls_storage = new_storage;
+                cur_storage = new_storage;
                 BARRIER;
-                capacity = new_cap;
+                cur_capacity = new_cap;
                 free(old_storage);
         }
         unsigned char *new_key_buf = malloc(key.len);
@@ -94,11 +107,36 @@ static int push(custom_labels_string_t key, custom_labels_string_t value) {
         memcpy(new_value_buf, value.buf, value.len);
         custom_labels_string_t new_key = {key.len, new_key_buf};
         custom_labels_string_t new_value = {value.len, new_value_buf};
-        tls_storage[tls_count] = (custom_labels_label_t) {new_key, new_value};
+        cur_storage[cur_count] = (custom_labels_label_t) {new_key, new_value};
         // Make sure the new item is written before the count is updated causing
         // the profiler to try to read it.
         BARRIER;
-        ++tls_count;
+        ++cur_count;
+        return 0;
+}
+
+static int labelset_push(custom_labels_labelset_t *ls, custom_labels_string_t key, custom_labels_string_t value) {
+        if (ls->count == ls->capacity) {
+                size_t new_cap = MAX(2 * cur_capacity, 1);
+                ls->storage = reallocarray(ls->storage, new_cap, sizeof(custom_labels_label_t));
+                ls->capacity = new_cap;
+                if (!ls->storage)
+                        return errno;
+        }
+        unsigned char *new_key_buf = malloc(key.len);
+        if (!new_key_buf) {
+                return errno;
+        }
+        memcpy(new_key_buf, key.buf, key.len);
+        unsigned char *new_value_buf = malloc(value.len);
+        if (!new_value_buf) {
+                free(new_key_buf);
+                return errno;
+        }
+        memcpy(new_value_buf, value.buf, value.len);
+        custom_labels_string_t new_key = {key.len, new_key_buf};
+        custom_labels_string_t new_value = {value.len, new_value_buf};
+        ls->storage[ls->count++] = (custom_labels_label_t) {new_key, new_value};
         return 0;
 }
 
@@ -106,10 +144,10 @@ static int push(custom_labels_string_t key, custom_labels_string_t value) {
 // by overwriting it with the last label and decrementing
 // `count` by one (thus changing the order of labels, but we don't care)
 static void swap_delete(custom_labels_label_t *element) {
-        assert(tls_count > 0);
-        custom_labels_label_t *last = tls_storage + tls_count - 1;
+        assert(cur_count > 0);
+        custom_labels_label_t *last = cur_storage + cur_count - 1;
         if (element == last) {
-                --tls_count;
+                --cur_count;
                 // Make sure memory is freed after decrementing the count
                 // causing profilers to no longer try to read it.
                 BARRIER;
@@ -141,11 +179,11 @@ static void swap_delete(custom_labels_label_t *element) {
         // The barrier ensures that the label is visible in `element` before it's no longer visible
         // in `last`.
         BARRIER;
-        --tls_count;
+        --cur_count;
 }
 
 void custom_labels_delete(custom_labels_string_t key) {
-        custom_labels_label_t *old = custom_labels_get_mut(key);
+        custom_labels_label_t *old = get_mut(key);
         if (old) {
                 swap_delete(old);
         }
@@ -153,14 +191,126 @@ void custom_labels_delete(custom_labels_string_t key) {
 
 int custom_labels_set(custom_labels_string_t key, custom_labels_string_t value) {
         assert(key.buf);
-        custom_labels_label_t *old = custom_labels_get_mut(key);
-        int old_idx = old ? old - tls_storage : -1;
+        custom_labels_label_t *old = get_mut(key);
+        int old_idx = old ? old - cur_storage : -1;
         int ret = push(key, value);
         if (ret) {
                 return ret;
         }
         if (old_idx >= 0) {
-                swap_delete(&tls_storage[old_idx]);
+                swap_delete(&cur_storage[old_idx]);
         }
         return 0;        
+}
+
+custom_labels_labelset_t *custom_labels_labelset_new(size_t capacity) {
+        custom_labels_labelset_t *ls = malloc(sizeof(custom_labels_labelset_t));
+        if (!ls)
+                return NULL;
+        custom_labels_label_t *storage = calloc(capacity, sizeof(custom_labels_label_t));
+        if (!storage) {
+                free(ls);
+                return NULL;
+        }
+        *ls = (custom_labels_labelset_t) { storage, 0, capacity };
+        return ls;
+}
+
+int custom_labels_labelset_set(custom_labels_labelset_t *ls, custom_labels_string_t key, custom_labels_string_t value) {
+        if (ls == custom_labels_current_set) {
+                return custom_labels_set(key, value);
+        }
+        assert(key.buf);
+        custom_labels_label_t *old = labelset_get_mut(ls, key);
+        if (old) {
+                old->value = value;
+                return 0;
+        }
+        return labelset_push(ls, key, value);
+}
+
+void custom_labels_labelset_free(custom_labels_labelset_t *ls) {        
+        if (!ls)
+                return;
+        assert(ls != custom_labels_current_set);
+        for (size_t i = 0; i < ls->count; ++i) {
+                free((void *)ls->storage[i].key.buf);
+                free((void *)ls->storage[i].value.buf);
+        }
+        free(ls->storage);
+        free(ls);
+}
+
+void custom_labels_labelset_delete(custom_labels_labelset_t *ls, custom_labels_string_t key) {
+        if (ls == custom_labels_current_set) {
+                return custom_labels_delete(key);
+        }
+        custom_labels_label_t *old = labelset_get_mut(ls, key);
+        if (old) {
+                // this block is like swap_delete, but far simpler due to not needing barriers
+                assert(ls->count > 0); // impossible to be empty if we got here.
+                custom_labels_label_t *last = &ls->storage[ls->count - 1];
+                if (last != old) {
+                        free((void *)old->key.buf);
+                        free((void *)old->value.buf);
+                        *old = *last;
+                }
+        }
+}
+
+custom_labels_labelset_t *custom_labels_labelset_replace(custom_labels_labelset_t *ls) {
+        custom_labels_labelset_t *old = custom_labels_current_set;
+        // Whatever operations the user tried to do on `ls` have to be finished
+        // before we install it
+        BARRIER;        
+        custom_labels_current_set = ls;
+        // likewise, we need to have installed it before
+        // the user tries to do anything with the old one.
+        BARRIER;
+        return old;
+}
+
+static int custom_labels_label_clone(custom_labels_label_t lbl, custom_labels_label_t *new_out) {
+        if (!new_out)
+                return 0;
+        unsigned char *new_key_buf = malloc(lbl.key.len);
+        if (!new_key_buf)
+                return errno;
+        memcpy(new_key_buf, lbl.key.buf, lbl.key.len);
+        new_out->key = (custom_labels_string_t) {lbl.key.len, new_key_buf };
+
+        unsigned char *new_val_buf = malloc(lbl.value.len);
+        if (!new_val_buf) {
+                free((void *)new_out->key.buf);
+                return errno;
+        }
+        memcpy(new_val_buf, lbl.value.buf, lbl.value.len);
+        new_out->value = (custom_labels_string_t) {lbl.value.len, new_val_buf };
+        return 0;
+}
+
+// it's fine to call this with the current label 
+custom_labels_labelset_t *custom_labels_labelset_clone(custom_labels_labelset_t *ls) {
+        custom_labels_labelset_t *new = custom_labels_labelset_new(ls->count);
+        if (!new)
+                return NULL;
+        for (size_t i = 0; i < ls->count; ++i) {
+                int ret = custom_labels_label_clone(ls->storage[i], &new->storage[i]);
+                if (ret) {
+                        new->count = i;
+                        custom_labels_labelset_free(new);
+                        return NULL;
+                }
+        }
+        new->count = ls->count;
+        return new;
+}
+
+// ok to call on current ls
+const custom_labels_label_t *custom_labels_labelset_get(custom_labels_labelset_t *ls, custom_labels_string_t key) {
+  return labelset_get_mut(ls, key);
+}
+
+const custom_labels_labelset_t *custom_labels_labelset_current() {
+  return custom_labels_current_set;
 }

--- a/src/customlabels.h
+++ b/src/customlabels.h
@@ -17,9 +17,17 @@ typedef struct {
         custom_labels_string_t value;
 } custom_labels_label_t;
 
+struct _custom_labels_ls;
+typedef struct _custom_labels_ls custom_labels_labelset_t;
+
+/**
+ * <div rustbindgen hide></div>
+ */
+extern __thread custom_labels_labelset_t *custom_labels_current_set;
+
 /**
  *
- * Get the label corresponding to a key, or NULL if none exists.
+ * Get the label corresponding to a key on the current label set, or NULL if none exists.
  *
  * SAFETY:
  * The caller must not attempt to mutate anything through the
@@ -33,12 +41,12 @@ typedef struct {
 const custom_labels_label_t *custom_labels_get(custom_labels_string_t key);
 
 /**
- * Delete a custom label, if it exists.
+ * Delete a custom label, if it exists, on the current label set.
  */
 void custom_labels_delete(custom_labels_string_t key);
 
 /**
- * Set a new custom label, or reset an existing one.
+ * Set a new custom label, or reset an existing one, on the current label set.
  *
  * SAFETY:
  * The caller must not pass a NULL value for key.buf
@@ -46,3 +54,60 @@ void custom_labels_delete(custom_labels_string_t key);
  * Returns 0 on success, `errno` otherwise.
  */
 int custom_labels_set(custom_labels_string_t key, custom_labels_string_t value);
+
+/**
+ * Create a new label set.
+ * 
+ * Returns the new label set on success, NULL on failure.
+ */
+custom_labels_labelset_t *custom_labels_labelset_new(size_t capacity);
+
+/**
+ * Set a new custom label, or reset an existing one, on a given label set.
+ * 
+ * SAFETY:
+ * The caller must not pass a NULL value for key.buf
+ * 
+ * Returns 0 on success, `errno` otherwise.
+ */
+int custom_labels_labelset_set(custom_labels_labelset_t *ls, custom_labels_string_t key, custom_labels_string_t value);
+
+/**
+ * Frees all memory associated with a label set.
+ * 
+ * SAFETY: The label set must not be currently installed.
+ */
+void custom_labels_labelset_free(custom_labels_labelset_t *ls);
+
+/**
+ * Delete a custom label, if it exists, on the given label set.
+ */
+void custom_labels_labelset_delete(custom_labels_labelset_t *ls, custom_labels_string_t key);
+
+/**
+ * Install the given label set as the current one, returning the old one.
+ */
+custom_labels_labelset_t *custom_labels_labelset_replace(custom_labels_labelset_t *ls);
+
+/**
+ * Clone the given label set.
+ * 
+ * Returns the clone on success, NULL otherwise.
+ */
+custom_labels_labelset_t *custom_labels_labelset_clone(custom_labels_labelset_t *ls);
+
+/**
+ * Get the label corresponding to a key on the given label set, or NULL if none exists.
+ * 
+ * SAFETY:
+ * The caller must not attempt to mutate anything through the returned pointer.
+ * 
+ * The caller must not attempt to access the returned pointer
+ * after any function that mutates the given label set is called.
+ */
+const custom_labels_label_t *custom_labels_labelset_get(custom_labels_labelset_t *ls, custom_labels_string_t key);
+
+/**
+ * Get the currently active label set.
+ */
+const custom_labels_labelset_t *custom_labels_labelset_current();


### PR DESCRIPTION
The main ABI change is that instead of storing the label set immediately in TLS, we store a pointer to it in TLS. That lets us replace label sets atomically with one instruction.