### PR TITLE
Add note explicitly making sure the crate won't try to change linker args on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ custom-labels = "0.4"
 Then add the following line to your executable's `build.rs`:
 
 ``` rust
+#[cfg(not(target_os="macos"))]
 custom_labels::build::emit_build_instructions();
 ```
 


### PR DESCRIPTION
My general motivation is that I spent a few hours getting this crate to compile on MacOS, and only then it occurred to me that I can just do this. 

I assume it won't actually work because there's no eBPF on MacOS (maybe other profilers can handle it?) + as far as I can tell macos adds an "_" to the beginning of every symbol, which will break the spec.

If you (or anyone else) is curious about what I put together, [here is the diff](https://github.com/polarsignals/custom-labels/compare/master...spiraldb:custom-labels:adamg/macos-support?expand=1).