### PR TITLE
Redesign JS API around the ThreadContext class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,111 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:      80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never

--- a/js/README.md
+++ b/js/README.md
@@ -113,11 +113,10 @@ signal and let the silent drop apply.
 Instance methods:
 
 - **`appendAttributes(attributes)`** — append attributes to this record
-  (positional, same shape as the constructor's `attributes`). Append-only:
-  existing entries are never overwritten. Appending at a key index that's
-  already in the record is allowed but inert — the OTEP specifies that
-  readers honor the first occurrence and ignore duplicates, so the new value
-  silently disappears. Avoid that. Entries that would push the encoded
+  (positional, same shape as the constructor's `attributes`). Appending with
+  a key index that's already in the record is allowed: OTEP-4947 duplicates
+  are last-wins, so the new value overwrites the earlier one for readers
+  that decode the record in full. Entries that would push the encoded
   payload past the 612-byte cap are silently dropped (skip-and-continue:
   smaller subsequent entries may still fit), and `isTruncated()` starts
   returning `true`.

--- a/js/README.md
+++ b/js/README.md
@@ -65,29 +65,23 @@ context.appendAttributes([, , '200']);  // index 2 = http.status, say
 clearContext();  // detach when the span ends
 ```
 
-If the caller maintains a stable list of attribute names — the same list
-published in the process context — `makeNamedContext` provides a name-based
-factory for `ThreadContext`:
+The same key list the caller writes into `ThreadContext`'s positional
+`attributes` argument has to be published alongside the on-the-wire
+record so a reader can decode the uint8 key indexes back to names.
+`getProcessContextAttributes(keys)` returns a snapshot of the OTEP-4719
+attributes (schema version, key map, V8 layout constants) ready to
+spread into the application's process-context attribute map:
 
 ```javascript
-const { makeNamedContext } = require('@polarsignals/custom-labels');
+const { getProcessContextAttributes } = require('@polarsignals/custom-labels');
 const keys = [
     'http.method', // index 0
     'http.route',  // index 1
 ];
-const named = makeNamedContext(keys);
-
-named.runWithContext(
-    () => handleRequest(),
-    {
-        traceId: Buffer.from('4bf92f3577b34da6a3ce929d0e0e4736', 'hex'),
-        spanId:  Buffer.from('00f067aa0ba902b7', 'hex'),
-        namedAttributes: {
-            'http.method': 'GET',
-            'http.route':  '/api/v1/widgets',
-        },
-    },
-);
+publishProcessContext({
+    ...getProcessContextAttributes(keys),
+    // ...the application's own attributes
+});
 ```
 
 ## API
@@ -170,47 +164,36 @@ Detach any `ThreadContext` from the current async-context frame, via
 `AsyncLocalStorage.enterWith(undefined)`. Idempotent when no context is
 attached. On non-Linux platforms this is a no-op.
 
-### `makeNamedContext(keys)`
+### `getProcessContextAttributes(keys)`
 
-Returns a factory object `{ buildContext, runWithContext, enterWithContext,
-clearContext, processContextAttributes }`. The `keys` array is the same
-string list the caller publishes (or has published) as the
-`threadlocal.attribute_key_map` resource attribute in the OTEP-4719 process
-context: index N in `keys` is uint8 key index N on the wire. The mapping is
-captured once at factory time.
+Returns a frozen, defensively-copied snapshot of the OTEP-4719
+process-context attributes that go with this writer's on-the-wire
+records. The `keys` array is the same string list the caller writes into
+`ThreadContext`'s positional `attributes` argument: index N in `keys` is
+uint8 key index N on the wire.
 
-- **`buildContext(opts)`** — resolves `opts.namedAttributes` against the key
-  map and returns a `ThreadContext`. `opts.namedAttributes` accepts a
-  `Record<string,unknown>`, a `Map`, or an `Array<[string,unknown]>`. Unknown
-  names throw.
-- **`enterWithContext(opts)`** — sugar for `buildContext(opts).enter()`.
-- **`runWithContext(fn, opts)`** — sugar for
-  `buildContext(opts).run(fn)`.
-- **`clearContext()`** — re-export of the module-level `clearContext()`.
-- **`processContextAttributes`** — frozen, defensively-copied snapshot of
-  the OTEP-4719 process-context attributes that correspond to this
-  `NamedContext`:
+`keys` is validated: must be a string array of length ≤ 256 with no
+duplicates.
 
 ```javascript
 {
-    'threadlocal.schema_version': 'nodejs_v1',
+    'threadlocal.schema_version': 'nodejs_v1_dev',
     'threadlocal.attribute_key_map': ['http.method', 'http.route', ...],
     // V8 layout constants captured from the V8 headers the addon was
     // compiled against — let the reader walk our wrapper and V8's
     // OrderedHashMap layout without having to derive these itself from
     // pointer-compression / sandbox build flags.
-    'threadlocal.nodejs_v1.wrapped_object_offset': 24,
-    'threadlocal.nodejs_v1.tagged_size': 8,
+    'threadlocal.wrapped_object_offset': 24,
+    'threadlocal.tagged_size': 8,
 }
 ```
 
-Spread it (or copy its entries) into whatever attribute map the application
-hands to its OTEP-4719 process-context publisher. Publishing the same
-`keys` you passed to `makeNamedContext` is the easiest way to keep the
-writer-side name-to-index mapping in sync with what an external reader will
-use to decode the on-the-wire `key_index` bytes back to names; the two
-`nodejs_v1.*` entries are V8 layout constants the reader needs to walk from
-our wrapper to the underlying record.
+Spread it (or copy its entries) into whatever attribute map the
+application hands to its OTEP-4719 process-context publisher. The
+`attribute_key_map` keeps the writer-side index→name mapping in sync with
+what an external reader will use to decode the on-the-wire `key_index`
+bytes; the two layout-constant entries are what the reader needs to walk
+from our V8 wrapper to the underlying record.
 
 ## Discovery contract (for reader implementers)
 

--- a/js/README.md
+++ b/js/README.md
@@ -1,12 +1,11 @@
 # OpenTelemetry thread-context writer for Node.js
 
-Node.js library for attaching [OpenTelemetry Thread Local Context Record (OTEP-4947)]
-[otep-4947] to asynchronous contexts at runtime. Records are propagated through
-asynchronous operations and can be used by external readers (such as the
-OpenTelemetry eBPF profiler) to correlate current execution context (e.g. stack
-traces) with distributed tracing, user contexts, or any other metadata.
-
-[otep-4947]: https://github.com/open-telemetry/opentelemetry-specification/pull/4947
+Node.js library for attaching [OpenTelemetry Thread Local Context Record (OTEP-4947)](
+  https://github.com/open-telemetry/opentelemetry-specification/pull/4947)
+to asynchronous contexts at runtime. Records are propagated through asynchronous
+operations and can be used by external readers (such as the OpenTelemetry eBPF
+profiler) to correlate current execution context (e.g. stack traces) with
+distributed tracing, user contexts, or any other metadata.
 
 ## Requirements
 
@@ -22,34 +21,56 @@ traces) with distributed tracing, user contexts, or any other metadata.
 ## Usage
 
 ```javascript
-const { runWithContext, enterWithContext, makeNamedContext } = require('@polarsignals/custom-labels');
+const { ThreadContext } = require('@polarsignals/custom-labels');
 
 // Trace and span IDs are raw bytes (Uint8Array of length 16 and 8). Buffer is
 // acceptable as a Uint8Array subclass.
-runWithContext(
-    () => {
-        // Code executed here will have the specified context record attached
-        // to it, including any async work that follows from it.
-        performWork();
-    },
-    {
-        traceId: Buffer.from('4bf92f3577b34da6a3ce929d0e0e4736', 'hex'),
-        spanId:  Buffer.from('00f067aa0ba902b7', 'hex'),
-        // attributes is positional: index N here = uint8 key index N in the
-        // wire record. Slots set to null/undefined or array holes are skipped.
-        // Key names come from threadlocal.attribute_key_map (OTEP-4719) — for
-        // this example, names at indexes 0 and 1 would be e.g. "http.method"
-        // and "http.route".
-        attributes: ['GET', '/api/v1/widgets'],
-    },
+const context = new ThreadContext(
+    Buffer.from('4bf92f3577b34da6a3ce929d0e0e4736', 'hex'),
+    Buffer.from('00f067aa0ba902b7', 'hex'),
+    // attributes is positional: index N here = uint8 key index N in the wire
+    // record. Slots set to null/undefined or array holes are skipped. Key
+    // names come from threadlocal.attribute_key_map (OTEP-4719) — for this
+    // example, names at indexes 0 and 1 would be e.g. "http.method" and
+    // "http.route".
+    ['GET', '/api/v1/widgets'],
 );
+
+context.run(() => {
+    // Code executed here sees `context` as the active thread-context record,
+    // including any async work that follows from it. The previous context (if
+    // any) is restored when this callback returns.
+    performWork();
+});
+```
+
+Callers typically build a `ThreadContext` once per logical scope (per trace
+span, say) and re-install the same JS reference on every async-context entry.
+The instance's `enter()` method does that without scoping to a callback;
+`getContext` returns whatever's currently attached; the module-level
+`clearContext()` detaches it:
+
+```javascript
+const { ThreadContext, getContext, clearContext } = require('@polarsignals/custom-labels');
+
+const context = new ThreadContext(traceId, spanId, ['GET', '/api/v1/widgets']);
+context.enter();
+// ... later, in the same async context (or a child) ...
+if (getContext() === context) { /* identity check, no byte comparison */ }
+
+// Late discovery of more attributes mutates the record in place, visible to
+// every async-context frame that holds this `context` reference:
+context.appendAttributes([, , '200']);  // index 2 = http.status, say
+
+clearContext();  // detach when the span ends
 ```
 
 If the caller maintains a stable list of attribute names — the same list
 published in the process context — `makeNamedContext` provides a name-based
-sugar API:
+factory for `ThreadContext`:
 
 ```javascript
+const { makeNamedContext } = require('@polarsignals/custom-labels');
 const keys = [
     'http.method', // index 0
     'http.route',  // index 1
@@ -71,154 +92,104 @@ named.runWithContext(
 
 ## API
 
-### `runWithContext(callback, opts)`
+### `new ThreadContext(traceId, spanId, attributes?)`
 
-Executes the callback function with the specified OTEP-4947 thread-context record attached to it. The record is automatically propagated through asynchronous operations spawned by the callback. The previous context (if any) is restored when the callback returns. The record is freed when no longer referenced.
+Construct a thread-context record. Caller manages the lifetime: the underlying
+native record is freed when no JS or async-context-frame reference survives.
 
 **Parameters:**
-- `callback` - Function to execute with context record attached
-- `opts`:
-  - `traceId` — 16 raw bytes (`Uint8Array`; `Buffer` works as a subclass).
-  - `spanId` — 8 raw bytes (`Uint8Array`; `Buffer` works as a subclass).
-  - `attributes` (optional) — positional `Array<string | null | undefined>`:
-    index N is the value for uint8 key index N on the wire. Slots that are
-    `null`, `undefined`, or array holes are skipped. Non-string values are
-    coerced via `toString`. Individual values longer than 255 UTF-8 bytes are
-    silently truncated to 255 (the on-the-wire length prefix is a uint8).
-    Array length must not exceed 256. Entries that would push the encoded
-    payload past 612 bytes (the OTEP-recommended 640-byte total-record cap
-    minus the 28-byte header) are silently dropped — see
-    {@link isContextTruncated} for how to detect that.
+- `traceId` — 16 raw bytes (`Uint8Array`; `Buffer` works as a subclass).
+- `spanId` — 8 raw bytes (`Uint8Array`; `Buffer` works as a subclass).
+- `attributes` (optional) — positional `Array<string | null | undefined>`:
+  index N is the value for uint8 key index N on the wire. Slots that are
+  `null`, `undefined`, or array holes are skipped. Non-string values are
+  coerced via `toString`. Individual values longer than 255 UTF-8 bytes are
+  silently truncated to 255 (the on-the-wire length prefix is a uint8). Array
+  length must not exceed 256. Entries that would push the encoded payload past
+  612 bytes (the OTEP-recommended 640-byte total-record cap minus the 28-byte
+  header) are silently dropped — see `isTruncated()` for how to detect that.
 
 Records are right-sized to fit the encoded payload: an empty attribute set
 produces a 28-byte record; small sets produce correspondingly small ones,
 with a single 64-byte cache-line allocation as the floor. The 612-byte
 ceiling matches the read buffer size of typical eBPF-based readers; if you
-know your readers are all in-process, you can ignore the
-`isContextTruncated` signal and let the silent drop apply.
+know your readers are all in-process, you can ignore the `isTruncated`
+signal and let the silent drop apply.
 
-**Synchronous callback:**
-```javascript
-runWithContext(
-    () => {
-        // Synchronous work will be associated with context record
-        processDataSync();
-    },
-    {
-        traceId: Buffer.from('4bf92f3577b34da6a3ce929d0e0e4736', 'hex'),
-        spanId:  Buffer.from('00f067aa0ba902b7', 'hex'),
-        attributes: ['GET', '/api/v1/widgets'],
-    },
-);
-```
+Instance methods:
 
-**Async callback:**
-```javascript
-await runWithContext(
-    async () => {
-        // Both synchronous and asynchronous work will be associated with context record
-        await processRequest();
-    },
-    {
-        traceId: Buffer.from('4bf92f3577b34da6a3ce929d0e0e4736', 'hex'),
-        spanId:  Buffer.from('00f067aa0ba902b7', 'hex'),
-        attributes: ['GET', '/api/v1/widgets'],
-    },
-);
-```
+- **`appendAttributes(attributes)`** — append attributes to this record
+  (positional, same shape as the constructor's `attributes`). Append-only:
+  existing entries are never overwritten. Appending at a key index that's
+  already in the record is allowed but inert — the OTEP specifies that
+  readers honor the first occurrence and ignore duplicates, so the new value
+  silently disappears. Avoid that. Entries that would push the encoded
+  payload past the 612-byte cap are silently dropped (skip-and-continue:
+  smaller subsequent entries may still fit), and `isTruncated()` starts
+  returning `true`.
 
-When passing an async function, `runWithContext` returns a Promise that must be awaited. When passing a synchronous function, it executes immediately and returns the function's result.
+  Mutations are visible to every async-context frame that holds the same
+  `ThreadContext` reference. Reallocate-on-append updates the wrapper's
+  internal record pointer in place — the JS object stays the same — so no
+  per-frame divergence.
 
-### `enterWithContext(opts)`
+- **`isTruncated()`** — returns `true` if at any point in this record's
+  lifetime — either at construction or in a subsequent `appendAttributes`
+  call — at least one attribute had to be dropped because it would have
+  pushed the record past the 612-byte attrs_data cap. Sticky: once true,
+  stays true.
 
-Attaches the supplied context to the current asynchronous scope without
-scoping it to a callback. Wraps `AsyncLocalStorage.enterWith`: the attachment
-persists until the current async context naturally ends (e.g. the request
-handler that called `enterWithContext` returns). Useful when a callback
-boundary is not a natural fit — for instance, when middleware sets context
-early in a request handler and wants it to apply to the rest of the handler
-chain.
+- **`enter()`** — attach this context to the current async-context frame
+  via `AsyncLocalStorage.enterWith(this)`. The attachment persists until
+  the current async context naturally ends, or until a subsequent
+  `enter()` / `run()` on a different context — or a `clearContext()` —
+  changes it. Re-installing the same `context` reference is cheap (no
+  allocation); the intended usage is to cache one `ThreadContext` per
+  logical scope on the caller side and re-install it across every
+  async-context fire.
 
-`opts` is the same as for `runWithContext`. Returns nothing.
+- **`run(callback)`** — scoped variant of `enter()`: runs `callback` with
+  this context attached and restores the prior context when the callback
+  returns. Wraps `AsyncLocalStorage.run(this, callback)`. When `callback`
+  returns a Promise, `run` returns the same Promise that must be awaited;
+  for a synchronous callback it executes immediately and returns the
+  callback's result.
+
+On non-Linux platforms, `ThreadContext` returns a no-op instance whose
+methods do nothing — the OTEP-4947 reader contract is ELF-TLSDESC, only
+meaningful on Linux.
+
+### `getContext()`
+
+Returns the `ThreadContext` currently attached to the active async-context
+frame, or `undefined` if none is.
 
 ### `clearContext()`
 
-Detach any thread-context record from the current asynchronous scope.
-Subsequent reads in the same scope (until a new `runWithContext` or
-`enterWithContext` attaches one) see no active context. Implemented as
-`AsyncLocalStorage.enterWith(undefined)`, which is the reason the
-discovery struct publishes the per-isolate `undefined_addr` — readers
-compare the value retrieved for our ALS key against it and bail cleanly
-when this method has been called.
-
-Idempotent: calling when there is no active context is a no-op. Useful,
-for instance, when a tracing span ends but the surrounding async
-context lives on for unrelated work.
-
-### `appendAttributes(attributes)`
-
-Append attributes to the active thread-context record without otherwise
-disturbing it. Intended for the common case where a tracing span starts
-with a base set of attributes and accumulates more (e.g. `http.status`,
-`error.message`) as the span runs.
-
-`attributes` has the same shape as `opts.attributes` in `runWithContext`:
-positional, index N is the value for uint8 key N, null/undefined/holes
-are skipped.
-
-**Append-only**: existing entries are never overwritten. Appending at a
-key index that's already in the record is allowed but inert — the OTEP
-specifies that readers honor the first occurrence and ignore duplicates,
-so the new value silently disappears. Avoid that.
-
-Entries that would push the encoded payload past the 612-byte cap are
-silently dropped (skip-and-continue: smaller subsequent entries may still
-fit), and `isContextTruncated` starts returning `true` for the current
-context.
-
-Throws if no `runWithContext`/`enterWithContext` is currently active.
-
-Implementation notes: small records are allocated to fit exactly within
-one 64-byte cache line (28-byte header + 36 bytes of attrs_data), giving
-a few short appends room to land in-place. When they don't, the allocation
-grows geometrically (×2) up to the 612-byte cap. In-place appends write
-the new entries past the current `attrs_data_size` (where the reader can't
-yet see them) and then publish them by bumping `attrs_data_size` itself
-— no `valid`-toggle dance, since the append is monotonic and
-`attrs_data_size` is the publication boundary. Reallocating appends swap
-the `record_` pointer and free the old buffer.
-
-### `isContextTruncated()`
-
-Returns `true` if at any point during the current context's lifetime — at
-construction (`runWithContext` / `enterWithContext`) or in a subsequent
-`appendAttributes` — at least one attribute was dropped because it would
-have pushed the record past the 612-byte attrs_data cap. The flag is
-sticky: once a record reports `true`, it stays `true` for the rest of
-that context's life.
-
-Returns `false` if there is no active context and on non-Linux platforms.
+Detach any `ThreadContext` from the current async-context frame, via
+`AsyncLocalStorage.enterWith(undefined)`. Idempotent when no context is
+attached. On non-Linux platforms this is a no-op.
 
 ### `makeNamedContext(keys)`
 
-Returns an object `{ runWithContext, enterWithContext, clearContext,
-appendAttributes, isContextTruncated, processContextAttributes }`. The
-first four methods are the name-addressed counterparts of the top-level
-functions of the same name (those that accept attributes do so by name
-instead of by position); `clearContext` and `isContextTruncated` are
-passthroughs to the same-named top-level functions, exposed on the
-named-context object for API symmetry. The
-`keys` array is the same string list the caller publishes (or has
-published) as the `threadlocal.attribute_key_map` resource attribute in
-the OTEP-4719 process context: index N in `keys` is uint8 key index N on
-the wire. The mapping is captured once at factory time.
+Returns a factory object `{ buildContext, runWithContext, enterWithContext,
+clearContext, processContextAttributes }`. The `keys` array is the same
+string list the caller publishes (or has published) as the
+`threadlocal.attribute_key_map` resource attribute in the OTEP-4719 process
+context: index N in `keys` is uint8 key index N on the wire. The mapping is
+captured once at factory time.
 
-`opts.namedAttributes` (and the argument to `appendAttributes`) accept a
-`Record<string,unknown>`, a `Map`, or an `Array<[string,unknown]>`. Unknown
-names throw.
-
-`processContextAttributes` is a frozen, defensively-copied snapshot of the
-OTEP-4719 process-context attributes that correspond to this `NamedContext`:
+- **`buildContext(opts)`** — resolves `opts.namedAttributes` against the key
+  map and returns a `ThreadContext`. `opts.namedAttributes` accepts a
+  `Record<string,unknown>`, a `Map`, or an `Array<[string,unknown]>`. Unknown
+  names throw.
+- **`enterWithContext(opts)`** — sugar for `buildContext(opts).enter()`.
+- **`runWithContext(fn, opts)`** — sugar for
+  `buildContext(opts).run(fn)`.
+- **`clearContext()`** — re-export of the module-level `clearContext()`.
+- **`processContextAttributes`** — frozen, defensively-copied snapshot of
+  the OTEP-4719 process-context attributes that correspond to this
+  `NamedContext`:
 
 ```javascript
 {
@@ -236,10 +207,10 @@ OTEP-4719 process-context attributes that correspond to this `NamedContext`:
 Spread it (or copy its entries) into whatever attribute map the application
 hands to its OTEP-4719 process-context publisher. Publishing the same
 `keys` you passed to `makeNamedContext` is the easiest way to keep the
-writer-side name-to-index mapping in sync with what an external reader
-will use to decode the on-the-wire `key_index` bytes back to names; the
-two `nodejs_v1.*` entries are V8 layout constants the reader needs to
-walk from our wrapper to the underlying record.
+writer-side name-to-index mapping in sync with what an external reader will
+use to decode the on-the-wire `key_index` bytes back to names; the two
+`nodejs_v1.*` entries are V8 layout constants the reader needs to walk from
+our wrapper to the underlying record.
 
 ## Discovery contract (for reader implementers)
 
@@ -268,21 +239,23 @@ The writer publishes three things the reader needs to find:
      singleton. The reader compares the value it retrieves for the ALS
      key against this *before* the internal-field-0 dereference. If equal,
      no context is currently attached (or whatever's there isn't a
-     CtxWrap) and the reader skips. Avoids reading garbage when the slot
-     happens to hold undefined.
+     ThreadContext) and the reader skips. Avoids reading garbage when the
+     slot happens to hold undefined.
 
   All four fields are fixed for a particular V8 isolate once computed.
   Since the Node.js model is to associate an isolate with a thread in a 1:1
   fashion, this also means that the values for a particular thread are fixed
   for the lifetime of the thread and can be cached by a reader.
 
-2. A JavaScript wrapper object (class name `CtxWrap`) stored as the value
-   for the ALS instance key inside the current `AsyncContextFrame` (itself
-   the V8 isolate's `ContinuationPreservedEmbedderData`). The wrapper is a
-   `node::ObjectWrap` subclass with a single non-inherited field:
+2. A JavaScript wrapper object (the `ThreadContext` JS class, internally a
+   `node::ObjectWrap` subclass named `CtxWrap` on the C++ side) stored as
+   the value for the ALS instance key inside the current
+   `AsyncContextFrame` (itself the V8 isolate's
+   `ContinuationPreservedEmbedderData`). The wrapper has a single
+   non-inherited field:
 
-   - `OtelThreadCtxRecord *record_` — pointer to the 640-byte record,
-     placed immediately after the `node::ObjectWrap` base subobject.
+   - `OtelThreadCtxRecord *record_` — pointer to the record, placed
+     immediately after the `node::ObjectWrap` base subobject.
 
 3. The record itself is exactly the OTEP-4947 layout: `trace_id[16]`,
    `span_id[8]`, `valid` (always 1, set during construction), `reserved`,
@@ -335,9 +308,9 @@ Entry* e = find_entry(table, als, ctx->als_identity_hash);
 if (!e) return NO_CONTEXT;           // ALS not present in this ACF
 if (e->value == ctx->undefined_addr) return NO_CONTEXT;  // explicit undefined
 
-// Entry value is the JS wrapper for our CtxWrap. Internal field 0 lives
-// at offset 3 * sizeof(uintptr_t) inside the JSObject and holds the raw
-// native pointer to the C++ wrapper directly (low bits zero because
+// Entry value is the JS wrapper for our ThreadContext. Internal field 0
+// lives at offset 3 * sizeof(uintptr_t) inside the JSObject and holds the
+// raw native pointer to the C++ wrapper directly (low bits zero because
 // the pointer is aligned and Node's V8 has no sandbox).
 auto* wrap_js = untag<JSObject>(e->value);
 auto* wrap = *(CtxWrap**)((char*)wrap_js + 3 * sizeof(uintptr_t));
@@ -350,29 +323,29 @@ if (record->valid != 1) return NO_CONTEXT;  // mid in-place update; skip
 ```
 
 The structural sketch above matches the actual layouts in every Node.js
-release in the v22–v26 range. Two refinements you'll want in a real
-implementation:
+release in the v22–v26 range. For real implementations, there's two additional
+aspects worth calling out:
 
-- **`OrderedHashMap` vs. `SmallOrderedHashMap`.** V8 may use a more
-  compact `SmallOrderedHashMap` layout for low-cardinality maps; in
-  practice the `AsyncContextFrame` map appears to always be the regular
-  `OrderedHashMap` (which is what the pseudo-code assumes), but a
-  defensive reader should sniff the layout before parsing.
+- **`OrderedHashMap` vs. `SmallOrderedHashMap`.** V8 defines a more compact
+  `SmallOrderedHashMap` layout as well, but a JS `Map` (which is what an
+  `AsyncContextFrame` is) always uses the regular `OrderedHashMap` that the
+  pseudo-code assumes. This is a guarantee about V8's current implementation
+  rather than a spec invariant, so a defensive reader may still sniff the layout
+  to be resilient against future V8 drift.
 - **Validation.** Trust nothing until you've checked at least
-  `record->valid == 1` — a pointer-chasing walk that lands in the wrong
-  place yields garbage at the same offsets. Additional sanity checks
+  `record->valid == 1` — a pointer-chasing walk that lands in the wrong place
+  yields garbage at the same offsets. Additional sanity checks
   (`attrs_data_size` is plausible, the bucket count is a power of two,
-  Smi-flagged words actually look like Smis) make the reader resilient
-  to version drift before the record itself is touched.
+  Smi-flagged words actually look like Smis) make the reader resilient to
+  version drift before the record itself is touched.
 
 ## Functionality not currently in scope
 
 * This component does not explicitly coordinate with OTEP-4719 process-context
   for either reading or updating the association of numeric key indices to their
   names.
-* We're not merging attribute sets in nested `runWithContext` invocations, a new
-  record completely replaces the previous record for the duration of the nested
-  invocation.
+* There's currently no support for either merging data from multiple records, or
+  indeed reading data from a record in-process.
 
 ## Development
 

--- a/js/addon.cpp
+++ b/js/addon.cpp
@@ -311,12 +311,12 @@ void CtxWrap::New(const FunctionCallbackInfo<Value> &args) {
   Local<Context> context = isolate->GetCurrentContext();
 
   if (!args.IsConstructCall()) [[unlikely]] {
-    isolate->ThrowError("CtxWrap must be called with `new`");
+    isolate->ThrowError("ThreadContext must be called with `new`");
     return;
   }
   if (args.Length() != 3) {
     isolate->ThrowError(
-        "CtxWrap expects 3 arguments: traceId, spanId, attributes");
+        "ThreadContext expects 3 arguments: traceId, spanId, attributes");
     return;
   }
 
@@ -389,7 +389,7 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
 
   CtxWrap *self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
-    isolate->ThrowError("not a CtxWrap");
+    isolate->ThrowError("not a ThreadContext");
     return;
   }
   if (args.Length() != 1) {
@@ -476,7 +476,7 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
 void CtxWrap::IsTruncated(const FunctionCallbackInfo<Value> &args) {
   CtxWrap *self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
-    args.GetIsolate()->ThrowError("not a CtxWrap");
+    args.GetIsolate()->ThrowError("not a ThreadContext");
     return;
   }
   args.GetReturnValue().Set(self->truncated_);
@@ -489,7 +489,7 @@ void CtxWrap::DebugBytes(const FunctionCallbackInfo<Value> &args) {
   Isolate *isolate = args.GetIsolate();
   CtxWrap *self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
-    isolate->ThrowError("not a CtxWrap");
+    isolate->ThrowError("not a ThreadContext");
     return;
   }
   const size_t total =
@@ -504,14 +504,14 @@ void CtxWrap::Init(Local<Object> exports) {
   Local<Context> context = isolate->GetCurrentContext();
 
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
-  tpl->SetClassName(String::NewFromUtf8Literal(isolate, "CtxWrap"));
+  tpl->SetClassName(String::NewFromUtf8Literal(isolate, "ThreadContext"));
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   tpl->PrototypeTemplate()->Set(
       String::NewFromUtf8Literal(isolate, "debugBytes"),
       FunctionTemplate::New(isolate, DebugBytes));
   tpl->PrototypeTemplate()->Set(
-      String::NewFromUtf8Literal(isolate, "append"),
+      String::NewFromUtf8Literal(isolate, "appendAttributes"),
       FunctionTemplate::New(isolate, Append));
   tpl->PrototypeTemplate()->Set(
       String::NewFromUtf8Literal(isolate, "isTruncated"),
@@ -519,7 +519,7 @@ void CtxWrap::Init(Local<Object> exports) {
 
   Local<Function> constructor = tpl->GetFunction(context).ToLocalChecked();
   exports
-      ->Set(context, String::NewFromUtf8Literal(isolate, "CtxWrap"),
+      ->Set(context, String::NewFromUtf8Literal(isolate, "ThreadContext"),
             constructor)
       .FromJust();
 }

--- a/js/addon.cpp
+++ b/js/addon.cpp
@@ -158,11 +158,11 @@ class CtxWrap : public ObjectWrap {
  private:
   static void New(const FunctionCallbackInfo<Value>& args);
   static void DebugBytes(const FunctionCallbackInfo<Value>& args);
-  static void Append(const FunctionCallbackInfo<Value>& args);
+  static void AppendAttributes(const FunctionCallbackInfo<Value>& args);
   static void IsTruncated(const FunctionCallbackInfo<Value>& args);
 
   // Encode the JS array at `attrs_val` into `out` as packed (key, len, value)
-  // entries. Same shape used by both New() and Append(). On a parse error
+  // entries. Same shape used by both New() and AppendAttributes(). On a parse error
   // (non-array, etc.) throws via `isolate` and returns false. On per-entry
   // overflow against the 612-byte attrs_data cap, the entry is dropped,
   // `*out_truncated` is set to true, and processing continues with the
@@ -192,7 +192,7 @@ class CtxWrap : public ObjectWrap {
   // `record_->attrs_data_size <= capacity_ <= MAX_ATTRS_DATA_SIZE`.
   size_t capacity_;
   // Set to true (once, never cleared) if at any point in this record's
-  // lifetime — during New() or any subsequent Append() — at least one
+  // lifetime — during New() or any subsequent AppendAttributes() — at least one
   // attribute had to be dropped because it would have pushed attrs_data
   // past MAX_ATTRS_DATA_SIZE.
   bool truncated_;
@@ -280,7 +280,7 @@ bool CtxWrap::EncodeAttrs(Isolate* isolate,
 
   // Phase 2: encode. From here on we don't call any V8 function that can
   // enter user JS; the record is safe to mutate under the assumption that
-  // no re-entrant Append will interleave.
+  // no re-entrant AppendAttributes will interleave.
   out->reserve(out->size() + coerced.size() * 4);
   for (const auto& [i, v] : coerced) {
 #if NODE_MAJOR_VERSION >= 24
@@ -395,7 +395,7 @@ void CtxWrap::New(const FunctionCallbackInfo<Value>& args) {
   // other field write, with an `atomic_signal_fence` to pin that ordering at
   // compile time and a volatile store so the compiler can't fold or hoist
   // the write. The signal fence + volatile store is also the protocol used
-  // by Append() in its in-place path.
+  // by AppendAttributes() in its in-place path.
   std::atomic_signal_fence(std::memory_order_release);
   *reinterpret_cast<volatile uint8_t*>(&record->valid) = 1;
 
@@ -408,7 +408,7 @@ void CtxWrap::New(const FunctionCallbackInfo<Value>& args) {
 // (if the appended bytes fit in the current allocation's slack) or
 // reallocates to a larger one (geometrically), keeping invariant
 // `record_->attrs_data_size <= capacity_`.
-void CtxWrap::Append(const FunctionCallbackInfo<Value>& args) {
+void CtxWrap::AppendAttributes(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
 
@@ -418,7 +418,7 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value>& args) {
     return;
   }
   if (args.Length() != 1) {
-    isolate->ThrowError("append expects 1 argument: attributes");
+    isolate->ThrowError("appendAttributes expects 1 argument: attributes");
     return;
   }
 
@@ -498,7 +498,7 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value>& args) {
 // Returns true if any attribute was ever dropped from this wrapper's
 // record because it would have pushed attrs_data past the cap — set during
 // CtxWrap::New() if the initial set didn't fit, or by any subsequent
-// CtxWrap::Append() call.
+// CtxWrap::AppendAttributes() call.
 void CtxWrap::IsTruncated(const FunctionCallbackInfo<Value>& args) {
   CtxWrap* self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
@@ -538,7 +538,7 @@ void CtxWrap::Init(Local<Object> exports) {
       FunctionTemplate::New(isolate, DebugBytes));
   tpl->PrototypeTemplate()->Set(
       String::NewFromUtf8Literal(isolate, "appendAttributes"),
-      FunctionTemplate::New(isolate, Append));
+      FunctionTemplate::New(isolate, AppendAttributes));
   tpl->PrototypeTemplate()->Set(
       String::NewFromUtf8Literal(isolate, "isTruncated"),
       FunctionTemplate::New(isolate, IsTruncated));

--- a/js/addon.cpp
+++ b/js/addon.cpp
@@ -196,6 +196,15 @@ class CtxWrap : public ObjectWrap {
   // attribute had to be dropped because it would have pushed attrs_data
   // past MAX_ATTRS_DATA_SIZE.
   bool truncated_;
+  // Reentrancy guard for AppendAttributes(). EncodeAttrs calls ToString
+  // on each attribute value, which can execute user JS (e.g. a custom
+  // `toString`) that in turn calls `appendAttributes` on the same
+  // ThreadContext. A reentrant call would mutate attrs_data_size out
+  // from under the outer call's `current_used` snapshot, causing the
+  // outer memcpy to overwrite the reentrant call's bytes and the outer
+  // attrs_data_size write to shrink the record. We reject the reentrant
+  // call instead.
+  bool encoding_;
 };
 
 // Pin the offset of `record_` — the field the reader walks to from the
@@ -218,7 +227,10 @@ CtxWrap::~CtxWrap() {
 }
 
 CtxWrap::CtxWrap(OtelThreadCtxRecord* record, size_t capacity, bool truncated)
-    : record_(record), capacity_(capacity), truncated_(truncated) {}
+    : record_(record),
+      capacity_(capacity),
+      truncated_(truncated),
+      encoding_(false) {}
 
 // Copy exactly `expected_bytes` bytes out of a JS Uint8Array (or subclass such
 // as Buffer) into `out`. Returns false if the value isn't a Uint8Array or its
@@ -261,13 +273,12 @@ bool CtxWrap::EncodeAttrs(Isolate* isolate,
     return false;
   }
 
-  // Phase 1: coerce every present value to a string up front. `ToString`
-  // may invoke user JS (a custom `toString` on the value), which could
-  // re-enter into this ThreadContext (e.g. via `appendAttributes`) and
-  // interleave with our writes to `out`. Doing all such coercion BEFORE
-  // touching `out` keeps the encode phase re-entrancy-free.
-  std::vector<std::pair<uint32_t, Local<String>>> coerced;
-  coerced.reserve(n);
+  // Reserve a conservative upper bound; reallocations are cheap but
+  // unnecessary for the typical small attribute set. `ToString` below can
+  // execute user JS (a custom `toString` on the value); a reentrant
+  // `appendAttributes` on the same ThreadContext is rejected by the
+  // guard in CtxWrap::AppendAttributes, so `out` is safe to mutate here.
+  out->reserve(out->size() + n * 4);
   for (uint32_t i = 0; i < n; ++i) {
     Local<Value> val_val;
     if (!attrs->Get(context, i).ToLocal(&val_val)) return false;
@@ -275,14 +286,6 @@ bool CtxWrap::EncodeAttrs(Isolate* isolate,
     if (val_val->IsUndefined() || val_val->IsNull()) continue;
     Local<String> v;
     if (!val_val->ToString(context).ToLocal(&v)) return false;
-    coerced.emplace_back(i, v);
-  }
-
-  // Phase 2: encode. From here on we don't call any V8 function that can
-  // enter user JS; the record is safe to mutate under the assumption that
-  // no re-entrant AppendAttributes will interleave.
-  out->reserve(out->size() + coerced.size() * 4);
-  for (const auto& [i, v] : coerced) {
 #if NODE_MAJOR_VERSION >= 24
     int v_utf8_len = static_cast<int>(v->Utf8LengthV2(isolate));
 #else
@@ -421,6 +424,24 @@ void CtxWrap::AppendAttributes(const FunctionCallbackInfo<Value>& args) {
     isolate->ThrowError("appendAttributes expects 1 argument: attributes");
     return;
   }
+
+  // Reject reentrant AppendAttributes on the same wrap. EncodeAttrs'
+  // `ToString` below can execute user JS, and if that JS calls
+  // `appendAttributes` on this same ThreadContext, the reentrant call
+  // would grow attrs_data_size out from under the outer call's
+  // `current_used` snapshot, causing the outer memcpy to overwrite the
+  // reentrant call's bytes and the outer attrs_data_size write to shrink
+  // the record.
+  if (self->encoding_) {
+    isolate->ThrowError(
+        "reentrant appendAttributes on the same ThreadContext is not allowed");
+    return;
+  }
+  self->encoding_ = true;
+  struct EncodingGuard {
+    CtxWrap* w;
+    ~EncodingGuard() { w->encoding_ = false; }
+  } guard{self};
 
   const size_t current_used = self->record_->attrs_data_size;
   std::vector<uint8_t> appended;

--- a/js/addon.cpp
+++ b/js/addon.cpp
@@ -260,17 +260,29 @@ bool CtxWrap::EncodeAttrs(Isolate* isolate,
     isolate->ThrowError("attributes array length must not exceed 256");
     return false;
   }
-  // Reserve a conservative upper bound; reallocations are cheap but
-  // unnecessary for the typical small attribute set.
-  out->reserve(out->size() + n * 4);
+
+  // Phase 1: coerce every present value to a string up front. `ToString`
+  // may invoke user JS (a custom `toString` on the value), which could
+  // re-enter into this ThreadContext (e.g. via `appendAttributes`) and
+  // interleave with our writes to `out`. Doing all such coercion BEFORE
+  // touching `out` keeps the encode phase re-entrancy-free.
+  std::vector<std::pair<uint32_t, Local<String>>> coerced;
+  coerced.reserve(n);
   for (uint32_t i = 0; i < n; ++i) {
     Local<Value> val_val;
     if (!attrs->Get(context, i).ToLocal(&val_val)) return false;
     // null / undefined / array holes mean "no value at this key index".
     if (val_val->IsUndefined() || val_val->IsNull()) continue;
-
     Local<String> v;
     if (!val_val->ToString(context).ToLocal(&v)) return false;
+    coerced.emplace_back(i, v);
+  }
+
+  // Phase 2: encode. From here on we don't call any V8 function that can
+  // enter user JS; the record is safe to mutate under the assumption that
+  // no re-entrant Append will interleave.
+  out->reserve(out->size() + coerced.size() * 4);
+  for (const auto& [i, v] : coerced) {
 #if NODE_MAJOR_VERSION >= 24
     int v_utf8_len = static_cast<int>(v->Utf8LengthV2(isolate));
 #else
@@ -327,9 +339,10 @@ void CtxWrap::New(const FunctionCallbackInfo<Value>& args) {
     isolate->ThrowError("ThreadContext must be called with `new`");
     return;
   }
-  if (args.Length() != 3) {
+  if (args.Length() < 2 || args.Length() > 3) {
     isolate->ThrowError(
-        "ThreadContext expects 3 arguments: traceId, spanId, attributes");
+        "ThreadContext expects 2 or 3 arguments: traceId, spanId, "
+        "attributes?");
     return;
   }
 
@@ -553,8 +566,6 @@ static void ResetDiscoveryStruct(void* /*arg*/) {
 }
 
 void StoreAls(const FunctionCallbackInfo<Value>& args) {
-  static thread_local bool cleanup_registered = false;
-
   Isolate* isolate = args.GetIsolate();
   if (!args[0]->IsObject()) {
     isolate->ThrowError("First argument must be the AsyncLocalStorage object.");
@@ -576,15 +587,21 @@ void StoreAls(const FunctionCallbackInfo<Value>& args) {
   // addon compiles on the older Node versions the package supports.
   otel_thread_ctx_nodejs_v1.cped_slot = nullptr;
 #endif
+  // `undefined_addr == 0` doubles as the "not yet initialized on this
+  // isolate" flag: it starts at zero (thread-local zero-init), any real
+  // V8 undefined singleton address is non-zero, and ResetDiscoveryStruct
+  // clears it back to zero — so a subsequent storeAls (e.g. isolate
+  // tear-down then re-init on the same thread) re-registers the cleanup
+  // hook. Register BEFORE the write so the flag transition is the last
+  // observable step.
+  if (otel_thread_ctx_nodejs_v1.undefined_addr == 0) {
+    node::AddEnvironmentCleanupHook(isolate, ResetDiscoveryStruct, nullptr);
+  }
   // Cache the per-isolate undefined singleton's tagged address. Undefined
   // is a read-only-roots heap object, never moves, so a cached numeric
   // address is fine — no Global<> tracking needed.
   otel_thread_ctx_nodejs_v1.undefined_addr =
       reinterpret_cast<v8::internal::Address>(*v8::Undefined(isolate));
-  if (!cleanup_registered) {
-    node::AddEnvironmentCleanupHook(isolate, ResetDiscoveryStruct, nullptr);
-    cleanup_registered = true;
-  }
 }
 
 // Without a function that explicitly reads the TLS variable, on x86 the

--- a/js/addon.cpp
+++ b/js/addon.cpp
@@ -1,9 +1,10 @@
 // Node.js writer for the OTEP-4947 Thread Local Context Record, adapted for
 // the Node.js asynchronous context model. The record is wrapped in a JS object
 // (CtxWrap) and stored in an AsyncLocalStorage instance; an out-of-process
-// reader discovers it by walking the V8 isolate's ContinuationPreservedEmbedderData
-// to the AsyncContextFrame (a JS Map), looking up the ALS instance as the key,
-// reading the resulting CtxWrap, and finally the record it owns.
+// reader discovers it by walking the V8 isolate's
+// ContinuationPreservedEmbedderData to the AsyncContextFrame (a JS Map),
+// looking up the ALS instance as the key, reading the resulting CtxWrap, and
+// finally the record it owns.
 
 #include <node.h>
 #include <node_object_wrap.h>
@@ -44,9 +45,9 @@ using v8::Object;
 // Layout is part of the reader ABI: see the README "Discovery contract"
 // section and the static_asserts below.
 struct otel_thread_ctx_nodejs_v1_t {
-  v8::internal::Address *cped_slot;  // offset 0
-  Global<Object> als_handle;         // offset sizeof(void*); one V8 internal pointer
-  int als_identity_hash;             // offset 2 * sizeof(void*); 4 bytes + 4 bytes padding
+  v8::internal::Address* cped_slot;  // offset 0
+  Global<Object> als_handle;  // offset sizeof(void*); one V8 internal pointer
+  int als_identity_hash;  // offset 2 * sizeof(void*); 4 bytes + 4 bytes padding
   v8::internal::Address undefined_addr;  // offset 3 * sizeof(void*); tagged
 };
 
@@ -59,18 +60,18 @@ __attribute__((visibility("default")))
 thread_local otel_thread_ctx_nodejs_v1_t otel_thread_ctx_nodejs_v1;
 }
 
-static_assert(sizeof(v8::Global<v8::Object>) == sizeof(void *),
+static_assert(sizeof(v8::Global<v8::Object>) == sizeof(void*),
               "Global<Object> must be exactly one pointer wide");
 static_assert(offsetof(otel_thread_ctx_nodejs_v1_t, cped_slot) == 0,
               "cped_slot must be at offset 0");
 static_assert(offsetof(otel_thread_ctx_nodejs_v1_t, als_handle) ==
-                  sizeof(void *),
+                  sizeof(void*),
               "als_handle must immediately follow cped_slot");
 static_assert(offsetof(otel_thread_ctx_nodejs_v1_t, als_identity_hash) ==
-                  2 * sizeof(void *),
+                  2 * sizeof(void*),
               "als_identity_hash must immediately follow als_handle");
 static_assert(offsetof(otel_thread_ctx_nodejs_v1_t, undefined_addr) ==
-                  3 * sizeof(void *),
+                  3 * sizeof(void*),
               "undefined_addr must follow als_identity_hash + padding");
 
 namespace otel_thread_ctx_nodejs {
@@ -84,8 +85,6 @@ using v8::Global;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
-using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Uint8Array;
@@ -117,7 +116,7 @@ static_assert(offsetof(OtelThreadCtxRecord, attrs_data) == 28,
               "attrs_data offset");
 
 struct OtelThreadCtxRecordDeleter {
-  void operator()(OtelThreadCtxRecord *p) const noexcept { free(p); }
+  void operator()(OtelThreadCtxRecord* p) const noexcept { free(p); }
 };
 using OwnedRecord =
     std::unique_ptr<OtelThreadCtxRecord, OtelThreadCtxRecordDeleter>;
@@ -151,16 +150,16 @@ class CtxWrap : public ObjectWrap {
   ~CtxWrap() override;
   static void Init(Local<Object> exports);
 
-  CtxWrap(const CtxWrap &) = delete;
-  CtxWrap &operator=(const CtxWrap &) = delete;
-  CtxWrap(CtxWrap &&) = delete;
-  CtxWrap &operator=(CtxWrap &&) noexcept = delete;
+  CtxWrap(const CtxWrap&) = delete;
+  CtxWrap& operator=(const CtxWrap&) = delete;
+  CtxWrap(CtxWrap&&) = delete;
+  CtxWrap& operator=(CtxWrap&&) noexcept = delete;
 
  private:
-  static void New(const FunctionCallbackInfo<Value> &args);
-  static void DebugBytes(const FunctionCallbackInfo<Value> &args);
-  static void Append(const FunctionCallbackInfo<Value> &args);
-  static void IsTruncated(const FunctionCallbackInfo<Value> &args);
+  static void New(const FunctionCallbackInfo<Value>& args);
+  static void DebugBytes(const FunctionCallbackInfo<Value>& args);
+  static void Append(const FunctionCallbackInfo<Value>& args);
+  static void IsTruncated(const FunctionCallbackInfo<Value>& args);
 
   // Encode the JS array at `attrs_val` into `out` as packed (key, len, value)
   // entries. Same shape used by both New() and Append(). On a parse error
@@ -168,11 +167,14 @@ class CtxWrap : public ObjectWrap {
   // overflow against the 612-byte attrs_data cap, the entry is dropped,
   // `*out_truncated` is set to true, and processing continues with the
   // next entry (a smaller subsequent entry may still fit).
-  static bool EncodeAttrs(Isolate *isolate, Local<Context> context,
-                          Local<Value> attrs_val, size_t existing_size,
-                          std::vector<uint8_t> *out, bool *out_truncated);
+  static bool EncodeAttrs(Isolate* isolate,
+                          Local<Context> context,
+                          Local<Value> attrs_val,
+                          size_t existing_size,
+                          std::vector<uint8_t>* out,
+                          bool* out_truncated);
 
-  CtxWrap(OtelThreadCtxRecord *record, size_t capacity, bool truncated);
+  CtxWrap(OtelThreadCtxRecord* record, size_t capacity, bool truncated);
 
   // The three fields are kept in one access section because C++ leaves
   // the relative layout of fields in different access controls
@@ -184,7 +186,7 @@ class CtxWrap : public ObjectWrap {
   // exposing them publicly keeps everything in one ordering-stable
   // block. Readers never touch them.
  public:
-  OtelThreadCtxRecord *record_;
+  OtelThreadCtxRecord* record_;
   // attrs_data capacity in bytes of the record_ allocation. The total
   // allocation is `sizeof(OtelThreadCtxRecord) + capacity_`. Always
   // `record_->attrs_data_size <= capacity_ <= MAX_ATTRS_DATA_SIZE`.
@@ -211,20 +213,23 @@ static_assert(offsetof(CtxWrap, record_) == sizeof(node::ObjectWrap),
               "subobject");
 #pragma GCC diagnostic pop
 
-CtxWrap::~CtxWrap() { free(record_); }
+CtxWrap::~CtxWrap() {
+  free(record_);
+}
 
-CtxWrap::CtxWrap(OtelThreadCtxRecord *record, size_t capacity, bool truncated)
+CtxWrap::CtxWrap(OtelThreadCtxRecord* record, size_t capacity, bool truncated)
     : record_(record), capacity_(capacity), truncated_(truncated) {}
 
 // Copy exactly `expected_bytes` bytes out of a JS Uint8Array (or subclass such
 // as Buffer) into `out`. Returns false if the value isn't a Uint8Array or its
 // length doesn't match.
-static bool CopyBytes(Local<Value> value, size_t expected_bytes, uint8_t *out) {
+static bool CopyBytes(Local<Value> value, size_t expected_bytes, uint8_t* out) {
   if (!value->IsUint8Array()) return false;
   Local<Uint8Array> arr = value.As<Uint8Array>();
   if (arr->ByteLength() != expected_bytes) return false;
-  uint8_t *base = static_cast<uint8_t *>(arr->Buffer()->GetBackingStore()->Data()) +
-                  arr->ByteOffset();
+  uint8_t* base =
+      static_cast<uint8_t*>(arr->Buffer()->GetBackingStore()->Data()) +
+      arr->ByteOffset();
   memcpy(out, base, expected_bytes);
   return true;
 }
@@ -237,9 +242,12 @@ static bool CopyBytes(Local<Value> value, size_t expected_bytes, uint8_t *out) {
 // entry whose encoding would push the combined size past MAX_ATTRS_DATA_SIZE
 // is dropped (not encoded into `*out`), `*out_truncated` is set, and
 // processing continues so a smaller subsequent entry may still fit.
-bool CtxWrap::EncodeAttrs(Isolate *isolate, Local<Context> context,
-                          Local<Value> attrs_val, size_t existing_size,
-                          std::vector<uint8_t> *out, bool *out_truncated) {
+bool CtxWrap::EncodeAttrs(Isolate* isolate,
+                          Local<Context> context,
+                          Local<Value> attrs_val,
+                          size_t existing_size,
+                          std::vector<uint8_t>* out,
+                          bool* out_truncated) {
   if (attrs_val->IsUndefined() || attrs_val->IsNull()) return true;
   if (!attrs_val->IsArray()) {
     isolate->ThrowError(
@@ -290,13 +298,18 @@ bool CtxWrap::EncodeAttrs(Isolate *isolate, Local<Context> context,
     // as the length prefix, and shrink the buffer back so the next entry
     // starts at exactly the right offset.
 #if NODE_MAJOR_VERSION >= 24
-    int v_written = static_cast<int>(v->WriteUtf8V2(
-        isolate, reinterpret_cast<char *>(&(*out)[entry_off + 2]),
-        static_cast<size_t>(v_budget), String::WriteFlags::kNone));
+    int v_written = static_cast<int>(
+        v->WriteUtf8V2(isolate,
+                       reinterpret_cast<char*>(&(*out)[entry_off + 2]),
+                       static_cast<size_t>(v_budget),
+                       String::WriteFlags::kNone));
 #else
-    int v_written = v->WriteUtf8(
-        isolate, reinterpret_cast<char *>(&(*out)[entry_off + 2]), v_budget,
-        nullptr, String::NO_NULL_TERMINATION);
+    int v_written =
+        v->WriteUtf8(isolate,
+                     reinterpret_cast<char*>(&(*out)[entry_off + 2]),
+                     v_budget,
+                     nullptr,
+                     String::NO_NULL_TERMINATION);
 #endif
     (*out)[entry_off + 1] = static_cast<uint8_t>(v_written);
     if (v_written < v_budget) {
@@ -306,8 +319,8 @@ bool CtxWrap::EncodeAttrs(Isolate *isolate, Local<Context> context,
   return true;
 }
 
-void CtxWrap::New(const FunctionCallbackInfo<Value> &args) {
-  Isolate *isolate = args.GetIsolate();
+void CtxWrap::New(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
 
   if (!args.IsConstructCall()) [[unlikely]] {
@@ -353,8 +366,7 @@ void CtxWrap::New(const FunctionCallbackInfo<Value> &args) {
   // appends).
   size_t capacity = std::max(attrs_buf.size(), MIN_INITIAL_CAPACITY);
   const size_t total = sizeof(OtelThreadCtxRecord) + capacity;
-  OwnedRecord record(
-      static_cast<OtelThreadCtxRecord *>(calloc(1, total)));
+  OwnedRecord record(static_cast<OtelThreadCtxRecord*>(calloc(1, total)));
   if (!record) {
     isolate->ThrowError("allocation failed");
     return;
@@ -372,9 +384,9 @@ void CtxWrap::New(const FunctionCallbackInfo<Value> &args) {
   // the write. The signal fence + volatile store is also the protocol used
   // by Append() in its in-place path.
   std::atomic_signal_fence(std::memory_order_release);
-  *reinterpret_cast<volatile uint8_t *>(&record->valid) = 1;
+  *reinterpret_cast<volatile uint8_t*>(&record->valid) = 1;
 
-  CtxWrap *self = new CtxWrap(record.release(), capacity, truncated);
+  CtxWrap* self = new CtxWrap(record.release(), capacity, truncated);
   self->Wrap(args.This());
   args.GetReturnValue().Set(args.This());
 }
@@ -383,11 +395,11 @@ void CtxWrap::New(const FunctionCallbackInfo<Value> &args) {
 // (if the appended bytes fit in the current allocation's slack) or
 // reallocates to a larger one (geometrically), keeping invariant
 // `record_->attrs_data_size <= capacity_`.
-void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
-  Isolate *isolate = args.GetIsolate();
+void CtxWrap::Append(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
 
-  CtxWrap *self = ObjectWrap::Unwrap<CtxWrap>(args.This());
+  CtxWrap* self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
     isolate->ThrowError("not a ThreadContext");
     return;
@@ -400,8 +412,8 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
   const size_t current_used = self->record_->attrs_data_size;
   std::vector<uint8_t> appended;
   bool truncated = false;
-  if (!EncodeAttrs(isolate, context, args[0], current_used, &appended,
-                   &truncated)) {
+  if (!EncodeAttrs(
+          isolate, context, args[0], current_used, &appended, &truncated)) {
     return;
   }
   if (truncated) self->truncated_ = true;
@@ -426,27 +438,28 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
     // mid-append sees either the old size (old extent, ignores the
     // half-written tail) or the new size (full new extent, all bytes
     // written). Either is consistent.
-    memcpy(&self->record_->attrs_data[current_used], appended.data(),
+    memcpy(&self->record_->attrs_data[current_used],
+           appended.data(),
            appended.size());
     std::atomic_signal_fence(std::memory_order_release);
-    *reinterpret_cast<volatile uint16_t *>(&self->record_->attrs_data_size) =
+    *reinterpret_cast<volatile uint16_t*>(&self->record_->attrs_data_size) =
         static_cast<uint16_t>(new_used);
     return;
   }
 
   // Doesn't fit. Reallocate with geometric growth with cap.
-  size_t new_cap = std::min(std::max(self->capacity_ * 2, new_used), MAX_ATTRS_DATA_SIZE);
+  size_t new_cap =
+      std::min(std::max(self->capacity_ * 2, new_used), MAX_ATTRS_DATA_SIZE);
 
   const size_t total = sizeof(OtelThreadCtxRecord) + new_cap;
-  OwnedRecord new_rec(
-      static_cast<OtelThreadCtxRecord *>(calloc(1, total)));
+  OwnedRecord new_rec(static_cast<OtelThreadCtxRecord*>(calloc(1, total)));
   if (!new_rec) {
     isolate->ThrowError("allocation failed");
     return;
   }
   // Copy the existing record (header + already-written attrs_data).
-  memcpy(new_rec.get(), self->record_,
-         sizeof(OtelThreadCtxRecord) + current_used);
+  memcpy(
+      new_rec.get(), self->record_, sizeof(OtelThreadCtxRecord) + current_used);
   // Append the new entries and update attrs_data_size.
   memcpy(&new_rec->attrs_data[current_used], appended.data(), appended.size());
   new_rec->attrs_data_size = static_cast<uint16_t>(new_used);
@@ -462,7 +475,7 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
   // writer is stopped during reads) take care of CPU-side ordering and make
   // immediate freeing of the old record safe.
   std::atomic_signal_fence(std::memory_order_release);
-  OtelThreadCtxRecord *old_rec = self->record_;
+  OtelThreadCtxRecord* old_rec = self->record_;
   self->record_ = new_rec.release();
   self->capacity_ = new_cap;
   std::atomic_signal_fence(std::memory_order_acq_rel);
@@ -473,8 +486,8 @@ void CtxWrap::Append(const FunctionCallbackInfo<Value> &args) {
 // record because it would have pushed attrs_data past the cap — set during
 // CtxWrap::New() if the initial set didn't fit, or by any subsequent
 // CtxWrap::Append() call.
-void CtxWrap::IsTruncated(const FunctionCallbackInfo<Value> &args) {
-  CtxWrap *self = ObjectWrap::Unwrap<CtxWrap>(args.This());
+void CtxWrap::IsTruncated(const FunctionCallbackInfo<Value>& args) {
+  CtxWrap* self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
     args.GetIsolate()->ThrowError("not a ThreadContext");
     return;
@@ -485,9 +498,9 @@ void CtxWrap::IsTruncated(const FunctionCallbackInfo<Value> &args) {
 // Debug accessor: returns the record (header + attrs_data) as a fresh
 // Uint8Array sized to the actual on-the-wire length. Not part of the stable
 // API; intended for tests and out-of-process-reader development.
-void CtxWrap::DebugBytes(const FunctionCallbackInfo<Value> &args) {
-  Isolate *isolate = args.GetIsolate();
-  CtxWrap *self = ObjectWrap::Unwrap<CtxWrap>(args.This());
+void CtxWrap::DebugBytes(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  CtxWrap* self = ObjectWrap::Unwrap<CtxWrap>(args.This());
   if (!self) {
     isolate->ThrowError("not a ThreadContext");
     return;
@@ -500,7 +513,7 @@ void CtxWrap::DebugBytes(const FunctionCallbackInfo<Value> &args) {
 }
 
 void CtxWrap::Init(Local<Object> exports) {
-  Isolate *isolate = Isolate::GetCurrent();
+  Isolate* isolate = Isolate::GetCurrent();
   Local<Context> context = isolate->GetCurrentContext();
 
   Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
@@ -519,7 +532,8 @@ void CtxWrap::Init(Local<Object> exports) {
 
   Local<Function> constructor = tpl->GetFunction(context).ToLocalChecked();
   exports
-      ->Set(context, String::NewFromUtf8Literal(isolate, "ThreadContext"),
+      ->Set(context,
+            String::NewFromUtf8Literal(isolate, "ThreadContext"),
             constructor)
       .FromJust();
 }
@@ -531,17 +545,17 @@ void CtxWrap::Init(Local<Object> exports) {
 // cleanup hook the first time StoreAls is called keeps the handle safely
 // scoped to the isolate, and the cped_slot pointer points into a struct that
 // won't exist once the isolate is gone.
-static void ResetDiscoveryStruct(void * /*arg*/) {
+static void ResetDiscoveryStruct(void* /*arg*/) {
   otel_thread_ctx_nodejs_v1.cped_slot = nullptr;
   otel_thread_ctx_nodejs_v1.als_handle.Reset();
   otel_thread_ctx_nodejs_v1.als_identity_hash = 0;
   otel_thread_ctx_nodejs_v1.undefined_addr = 0;
 }
 
-void StoreAls(const FunctionCallbackInfo<Value> &args) {
+void StoreAls(const FunctionCallbackInfo<Value>& args) {
   static thread_local bool cleanup_registered = false;
 
-  Isolate *isolate = args.GetIsolate();
+  Isolate* isolate = args.GetIsolate();
   if (!args[0]->IsObject()) {
     isolate->ThrowError("First argument must be the AsyncLocalStorage object.");
     return;
@@ -550,9 +564,10 @@ void StoreAls(const FunctionCallbackInfo<Value> &args) {
   otel_thread_ctx_nodejs_v1.als_identity_hash = obj->GetIdentityHash();
   otel_thread_ctx_nodejs_v1.als_handle = Global<Object>(isolate, obj);
 #if NODE_MAJOR_VERSION >= 22
-  otel_thread_ctx_nodejs_v1.cped_slot = reinterpret_cast<v8::internal::Address *>(
-      reinterpret_cast<char *>(isolate) +
-      v8::internal::Internals::kContinuationPreservedEmbedderDataOffset);
+  otel_thread_ctx_nodejs_v1.cped_slot =
+      reinterpret_cast<v8::internal::Address*>(
+          reinterpret_cast<char*>(isolate) +
+          v8::internal::Internals::kContinuationPreservedEmbedderDataOffset);
 #else
   // Node < 22 lacks ContinuationPreservedEmbedderData entirely (and the
   // associated V8 internal offset). The JS layer refuses to install the
@@ -576,8 +591,8 @@ void StoreAls(const FunctionCallbackInfo<Value> &args) {
 // linker may strip the symbol from the dynamic symbol table even though `nm`
 // still reports it, breaking out-of-process discovery. This is the same
 // workaround as the legacy custom-labels addon.
-void GetStoredAlsHash(const FunctionCallbackInfo<Value> &args) {
-  Isolate *isolate = args.GetIsolate();
+void GetStoredAlsHash(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(
       Integer::New(isolate, otel_thread_ctx_nodejs_v1.als_identity_hash));
 }
@@ -620,7 +635,7 @@ NODE_MODULE_INIT() {
   NODE_SET_METHOD(exports, "storeAls", StoreAls);
   NODE_SET_METHOD(exports, "getStoredAlsHash", GetStoredAlsHash);
 
-  Isolate *isolate = Isolate::GetCurrent();
+  Isolate* isolate = Isolate::GetCurrent();
   exports
       ->Set(context,
             String::NewFromUtf8Literal(isolate, "wrappedObjectOffset"),
@@ -635,4 +650,4 @@ NODE_MODULE_INIT() {
 
 #pragma GCC diagnostic pop
 
-} // namespace otel_thread_ctx_nodejs
+}  // namespace otel_thread_ctx_nodejs

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -32,7 +32,7 @@ export interface NamedContextOptions {
  * attribute map can spread this object into its own attributes.
  */
 export interface ProcessContextAttributes {
-    readonly 'threadlocal.schema_version': 'nodejs_v1';
+    readonly 'threadlocal.schema_version': 'nodejs_v1_dev';
     readonly 'threadlocal.attribute_key_map': readonly string[];
 
     /**
@@ -42,14 +42,14 @@ export interface ProcessContextAttributes {
      * from the V8 headers at addon-compile time so the reader doesn't have
      * to derive it from V8's pointer-compression / sandbox build flags.
      */
-    readonly 'threadlocal.nodejs_v1.wrapped_object_offset': number;
+    readonly 'threadlocal.wrapped_object_offset': number;
 
     /**
      * V8's tagged-pointer width in bytes (4 with pointer compression, 8
      * without). The reader can use this to derive the JSMap-, FixedArray-,
      * and OrderedHashMap-header offsets it walks without hardcoding them.
      */
-    readonly 'threadlocal.nodejs_v1.tagged_size': number;
+    readonly 'threadlocal.tagged_size': number;
 }
 
 /**

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -1,31 +1,8 @@
 /**
- * Inputs to {@link NamedContext.buildContext} (and the convenience methods
- * that delegate to it).
- *
- * `traceId` and `spanId` are passed as raw bytes (a `Uint8Array` of length 16
- * and 8 respectively; `Buffer` is acceptable as a subclass).
- *
- * `namedAttributes` are resolved to positional uint8 key indexes via the
- * `keys` array passed to {@link makeNamedContext}. Values are coerced to
- * strings via `toString`. Values longer than 255 UTF-8 bytes are silently
- * truncated, and attributes that would overflow the 612-byte payload cap
- * are silently dropped (see {@link ThreadContext.isTruncated}). Names that
- * aren't in the key map throw.
- */
-export interface NamedContextOptions {
-    traceId: Uint8Array;
-    spanId: Uint8Array;
-    namedAttributes?:
-        | Record<string, unknown>
-        | Map<string, unknown>
-        | Array<[string, unknown]>;
-}
-
-/**
  * OTEP-4719 process-context attributes corresponding to a particular
- * {@link NamedContext}. Suitable for publishing as part of the application's
- * process context so an out-of-process reader can decode the uint8 key
- * indexes emitted in each thread-context record back to attribute names.
+ * key list. Suitable for publishing as part of the application's process
+ * context so an out-of-process reader can decode the uint8 key indexes
+ * emitted in each thread-context record back to attribute names.
  *
  * The shape matches the OTEP-4947 process-context schema verbatim: an
  * application that publishes its process context as a flat string-keyed
@@ -128,30 +105,6 @@ export interface ThreadContextCtor {
 }
 
 /**
- * Object returned by {@link makeNamedContext}. Resolves the
- * `namedAttributes` map to a positional array against the key list
- * captured at factory time and builds a {@link ThreadContext};
- * convenience methods compose with {@link ThreadContext.enter} /
- * {@link ThreadContext.run}.
- */
-export interface NamedContext {
-    /** Allocate a ThreadContext with attributes resolved positionally by name. */
-    buildContext(opts: NamedContextOptions): ThreadContext;
-    /** Sugar: `buildContext(opts).enter()`. */
-    enterWithContext(opts: NamedContextOptions): void;
-    /** Sugar: `buildContext(opts).run(fn)`. */
-    runWithContext<T>(fn: () => T, opts: NamedContextOptions): T;
-    /** Sugar: re-export of the module-level {@link clearContext}. */
-    clearContext(): void;
-    /**
-     * Snapshot of the OTEP-4719 process-context attributes the caller should
-     * publish to keep this context's key map in sync with what readers see.
-     * Immutable; safe to spread directly into the caller's attribute map.
-     */
-    readonly processContextAttributes: ProcessContextAttributes;
-}
-
-/**
  * Construct a thread-context record. Caller manages the lifetime. On
  * non-Linux platforms, returns a no-op instance.
  */
@@ -171,11 +124,16 @@ export function getContext(): ThreadContext | undefined;
 export function clearContext(): void;
 
 /**
- * Build a name-addressed factory for {@link ThreadContext}. The supplied
- * `keys` array is the same string list the caller publishes (or has
- * published) as the `threadlocal.attribute_key_map` resource attribute in
- * the OTEP-4719 process context: index N in this array is the uint8 key
- * index N in the on-the-wire record. The mapping is captured once at
- * factory time.
+ * Returns the OTEP-4719 process-context attributes the caller should
+ * publish so an out-of-process reader can decode the on-the-wire uint8
+ * key indexes back to attribute names. The supplied `keys` array is the
+ * same string list the caller writes into the positional `attributes`
+ * argument of {@link ThreadContext}: index N here is the uint8 key index
+ * N in each record.
+ *
+ * `keys` is validated: must be a string array of length ≤ 256 with no
+ * duplicates.
  */
-export function makeNamedContext(keys: string[]): NamedContext;
+export function getProcessContextAttributes(
+    keys: string[],
+): ProcessContextAttributes;

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -1,27 +1,16 @@
 /**
- * Inputs to {@link runWithContext} and {@link enterWithContext}.
+ * Inputs to {@link NamedContext.buildContext} (and the convenience methods
+ * that delegate to it).
  *
  * `traceId` and `spanId` are passed as raw bytes (a `Uint8Array` of length 16
  * and 8 respectively; `Buffer` is acceptable as a subclass).
  *
- * `attributes`, if present, is positional: index N in the array is the value
- * for uint8 key index N on the wire. Slots that are `null`, `undefined`, or
- * absent (array holes) are skipped. Non-string values are coerced via
- * `toString`. Values longer than 255 UTF-8 bytes are silently truncated and
- * attributes that would overflow the 612-byte payload budget are silently
- * dropped. Array length must not exceed 256.
- */
-export interface ContextOptions {
-    traceId: Uint8Array;
-    spanId: Uint8Array;
-    attributes?: Array<string | null | undefined>;
-}
-
-/**
- * Inputs to the methods returned by {@link makeNamedContext}. Same as
- * {@link ContextOptions} but attributes are addressed by name; names are
- * resolved to uint8 key indexes using the array passed to
- * {@link makeNamedContext}.
+ * `namedAttributes` are resolved to positional uint8 key indexes via the
+ * `keys` array passed to {@link makeNamedContext}. Values are coerced to
+ * strings via `toString`. Values longer than 255 UTF-8 bytes are silently
+ * truncated, and attributes that would overflow the 612-byte payload cap
+ * are silently dropped (see {@link ThreadContext.isTruncated}). Names that
+ * aren't in the key map throw.
  */
 export interface NamedContextOptions {
     traceId: Uint8Array;
@@ -64,56 +53,96 @@ export interface ProcessContextAttributes {
 }
 
 /**
- * Object returned by {@link makeNamedContext}. Each method mirrors the
- * top-level function of the same name, but accepts attributes by name
- * instead of positionally.
+ * A thread-context record. Construct with `new ThreadContext(...)`; install
+ * via the {@link enter} or {@link run} instance methods. The underlying
+ * native record is GC-owned: when no JS or async-context-frame reference
+ * survives, it's freed.
+ *
+ * `appendAttributes` mutates the record in place. Because every async-context
+ * frame that holds the same `ThreadContext` reference observes the same
+ * native record buffer, an append is visible across all those frames even
+ * when the reallocate path runs (the wrapper's internal pointer is updated,
+ * the JS object is not replaced).
  */
-export interface NamedContext {
-    runWithContext<T>(fn: () => T, opts: NamedContextOptions): T;
-    enterWithContext(opts: NamedContextOptions): void;
-
+export interface ThreadContext {
     /**
-     * Same as the top-level {@link clearContext}, exposed on the named
-     * context for API symmetry. Detaches any thread-context record from
-     * the current asynchronous scope.
-     */
-    clearContext(): void;
-
-    /**
-     * Append attributes to the currently active thread-context record (the
-     * one a prior `runWithContext` or `enterWithContext` attached). Names
-     * are resolved to indices via the keys passed to {@link makeNamedContext}.
-     *
-     * The argument accepts the same shapes as
-     * {@link NamedContextOptions.namedAttributes}.
-     *
-     * Append-only: existing attributes are never modified. If a caller
-     * appends at a key that's already present, the OTEP "reader takes the
-     * first occurrence" rule means the new value is inert; avoid that.
+     * Append attributes to this record (positional, same shape as the
+     * constructor's `attributes` argument). Append-only: existing
+     * attributes are never modified.
      *
      * Attributes that would push the record past the 612-byte attrs_data
-     * cap are silently dropped, and {@link isContextTruncated} starts
-     * returning `true` for the current context.
-     *
-     * Throws if no context is currently attached.
+     * cap are silently dropped, and {@link isTruncated} starts returning
+     * `true`.
      */
-    appendAttributes(
-        namedAttributes:
-            | Record<string, unknown>
-            | Map<string, unknown>
-            | Array<[string, unknown]>,
-    ): void;
+    appendAttributes(attributes: Array<string | null | undefined> | undefined): void;
 
     /**
-     * Returns true if at any point during the current context's lifetime —
-     * either at construction (`runWithContext` / `enterWithContext`) or in
-     * a subsequent `appendAttributes` call — at least one attribute had
-     * to be dropped because it would have pushed the record past the
-     * 612-byte attrs_data cap. Always returns false if no context is
-     * currently attached.
+     * True if at any point in this context's lifetime — either at
+     * construction or in a subsequent {@link appendAttributes} call — at
+     * least one attribute had to be dropped because it would have pushed
+     * the record past the 612-byte attrs_data cap.
      */
-    isContextTruncated(): boolean;
+    isTruncated(): boolean;
 
+    /** Debug-only: returns the on-the-wire record bytes. Not stable. */
+    debugBytes(): Uint8Array;
+
+    /**
+     * Attach this context to the current async-context frame (and every
+     * frame derived from it until the frame ends or {@link clearContext}
+     * detaches it). Re-installing the same context reference is cheap (no
+     * allocation); per-span caching of the context on the caller side is
+     * the intended usage pattern.
+     *
+     * On non-Linux platforms this is a no-op.
+     */
+    enter(): void;
+
+    /**
+     * Attach this context for the duration of `fn`. Equivalent to
+     * `als.run(this, fn)` — after `fn` returns, the previous context is
+     * restored. Returns whatever `fn` returns; if `fn` returns a Promise,
+     * the same Promise is propagated. On non-Linux platforms simply
+     * invokes `fn`.
+     */
+    run<T>(fn: () => T): T;
+}
+
+/**
+ * Constructor for {@link ThreadContext}. `attributes`, if present, is
+ * positional: index N is the value for uint8 key index N on the wire.
+ * Slots that are `null`, `undefined`, or absent (array holes) are skipped.
+ * Non-string values are coerced via `toString`. Array length must not
+ * exceed 256.
+ *
+ * On non-Linux platforms, returns a no-op instance whose methods do
+ * nothing — the OTEP-4947 reader contract is ELF-TLSDESC, only meaningful
+ * on Linux.
+ */
+export interface ThreadContextCtor {
+    new (
+        traceId: Uint8Array,
+        spanId: Uint8Array,
+        attributes?: Array<string | null | undefined>,
+    ): ThreadContext;
+}
+
+/**
+ * Object returned by {@link makeNamedContext}. Resolves the
+ * `namedAttributes` map to a positional array against the key list
+ * captured at factory time and builds a {@link ThreadContext};
+ * convenience methods compose with {@link ThreadContext.enter} /
+ * {@link ThreadContext.run}.
+ */
+export interface NamedContext {
+    /** Allocate a ThreadContext with attributes resolved positionally by name. */
+    buildContext(opts: NamedContextOptions): ThreadContext;
+    /** Sugar: `buildContext(opts).enter()`. */
+    enterWithContext(opts: NamedContextOptions): void;
+    /** Sugar: `buildContext(opts).run(fn)`. */
+    runWithContext<T>(fn: () => T, opts: NamedContextOptions): T;
+    /** Sugar: re-export of the module-level {@link clearContext}. */
+    clearContext(): void;
     /**
      * Snapshot of the OTEP-4719 process-context attributes the caller should
      * publish to keep this context's key map in sync with what readers see.
@@ -123,79 +152,30 @@ export interface NamedContext {
 }
 
 /**
- * Run `fn` with an OTEP-4947 thread-context record attached to the current
- * asynchronous context. The record propagates through asynchronous
- * continuations and Node.js IO callbacks transparently via
- * `AsyncLocalStorage.run`, and is restored to its prior value when `fn`
- * returns (or its returned promise settles).
- *
- * On non-Linux platforms this is a no-op that simply invokes `fn`.
+ * Construct a thread-context record. Caller manages the lifetime. On
+ * non-Linux platforms, returns a no-op instance.
  */
-export function runWithContext<T>(fn: () => T, opts: ContextOptions): T;
+export const ThreadContext: ThreadContextCtor;
 
 /**
- * Attach an OTEP-4947 thread-context record to the current asynchronous
- * context via `AsyncLocalStorage.enterWith`. Unlike {@link runWithContext}
- * there is no scope: the attachment persists until the current async context
- * naturally ends (e.g. the request handler that called `enterWithContext`
- * returns).
- *
- * On non-Linux platforms this is a no-op.
+ * Returns the {@link ThreadContext} currently attached to the active
+ * async-context frame, or `undefined` if none is.
  */
-export function enterWithContext(opts: ContextOptions): void;
+export function getContext(): ThreadContext | undefined;
 
 /**
- * Detach any thread-context record from the current asynchronous scope.
- * Subsequent reads in the same scope (until a new
- * {@link runWithContext}/{@link enterWithContext} attaches one) see no
- * active context. Useful, for instance, when a tracing span ends but the
- * surrounding async context lives on for unrelated work.
- *
- * Idempotent: calling when there is no active context is a no-op.
- *
- * On non-Linux platforms this is a no-op.
+ * Detach any {@link ThreadContext} from the current async-context frame.
+ * Idempotent when no context is attached. On non-Linux platforms this is
+ * a no-op.
  */
 export function clearContext(): void;
 
 /**
- * Append attributes to the currently active thread-context record (the one
- * a prior {@link runWithContext} or {@link enterWithContext} attached).
- * Positional, same shape as {@link ContextOptions.attributes}.
- *
- * Append-only: existing attributes are never modified. If a caller appends
- * at a key index that's already present, the OTEP "reader takes the first
- * occurrence" rule means the new value is inert; avoid that.
- *
- * Attributes that would push the record past the 612-byte attrs_data cap
- * are silently dropped, and {@link isContextTruncated} starts returning
- * `true` for the current context.
- *
- * Throws if no context is currently attached.
- *
- * On non-Linux platforms this is a no-op.
- */
-export function appendAttributes(
-    attributes: Array<string | null | undefined>,
-): void;
-
-/**
- * Returns true if at any point during the current context's lifetime —
- * either at construction (via {@link runWithContext} / {@link enterWithContext})
- * or in a subsequent {@link appendAttributes} call — at least one attribute
- * had to be dropped because it would have pushed the record past the
- * 612-byte attrs_data cap.
- *
- * Returns false if no context is currently attached, and on non-Linux
- * platforms.
- */
-export function isContextTruncated(): boolean;
-
-/**
- * Build name-addressed wrappers around {@link runWithContext} and
- * {@link enterWithContext}. The supplied `keys` array is the same string
- * list the caller publishes (or has published) as the
- * `threadlocal.attribute_key_map` resource attribute in the OTEP-4719 process
- * context: index N in this array is the uint8 key index N in the on-the-wire
- * record. The mapping is captured once at factory time.
+ * Build a name-addressed factory for {@link ThreadContext}. The supplied
+ * `keys` array is the same string list the caller publishes (or has
+ * published) as the `threadlocal.attribute_key_map` resource attribute in
+ * the OTEP-4719 process context: index N in this array is the uint8 key
+ * index N in the on-the-wire record. The mapping is captured once at
+ * factory time.
  */
 export function makeNamedContext(keys: string[]): NamedContext;

--- a/js/index.js
+++ b/js/index.js
@@ -101,90 +101,44 @@ if (process.platform === 'linux') {
 }
 
 /**
- * Build a name-addressed factory for ThreadContext. The supplied `keys`
- * array is the same string list the caller publishes (or has published)
- * as the `threadlocal.attribute_key_map` resource attribute in the
- * OTEP-4719 process context: index N in this array is the uint8 key
- * index N in the on-the-wire record. The mapping is captured once at
- * factory time.
+ * Snapshot of the OTEP-4719 process-context attributes the caller should
+ * publish so an out-of-process reader can (a) decode the on-the-wire
+ * uint8 key indexes back to names and (b) walk V8's wrapper / hashmap
+ * layout without doing its own V8-internal symbol lookups. The `keys`
+ * argument is the same string list the caller writes into ThreadContext's
+ * positional attributes array: index N in this array is the uint8 key
+ * index N in the on-the-wire record.
+ *
+ * The returned object is frozen and defensively copied; safe to spread
+ * into the caller's process-context attribute map.
  */
-function makeNamedContext(keys) {
+function getProcessContextAttributes(keys) {
     if (!Array.isArray(keys)) {
         throw new TypeError('keys must be an array of attribute names');
     }
     if (keys.length > 256) {
         throw new RangeError('keys array exceeds 256 entries');
     }
-    const indexByName = new Map();
-    keys.forEach((name, i) => {
+    const seen = new Set();
+    for (let i = 0; i < keys.length; ++i) {
+        const name = keys[i];
         if (typeof name !== 'string') {
             throw new TypeError('every key must be a string');
         }
-        if (indexByName.has(name)) {
-            throw new Error(`duplicate key name at indexes ${indexByName.get(name)} and ${i}: ${name}`);
+        if (seen.has(name)) {
+            throw new Error(`duplicate key name at index ${i}: ${name}`);
         }
-        indexByName.set(name, i);
-    });
-
-    function resolveAttributes(named) {
-        if (named === null || named === undefined) return undefined;
-        const attributes = [];
-        const set = (name, value) => {
-            const idx = indexByName.get(name);
-            if (idx === undefined) {
-                throw new Error(`unknown attribute name: ${name}`);
-            }
-            attributes[idx] = String(value);
-        };
-        if (Array.isArray(named)) {
-            for (const [n, v] of named) set(n, v);
-        } else if (named instanceof Map) {
-            for (const [n, v] of named) set(n, v);
-        } else if (typeof named === 'object') {
-            for (const n of Object.keys(named)) set(n, named[n]);
-        } else {
-            throw new TypeError('namedAttributes must be an object, Map, or array of pairs');
-        }
-        return attributes;
+        seen.add(name);
     }
-
-    function buildContext(opts) {
-        if (!opts || typeof opts !== 'object') {
-            throw new TypeError('options object required');
-        }
-        return new ThreadContext(opts.traceId, opts.spanId, resolveAttributes(opts.namedAttributes));
-    }
-
-    // Snapshot of the OTEP-4719 process-context attributes the caller should
-    // publish so an out-of-process reader can (a) decode key indices back to
-    // names and (b) walk V8's wrapper/hashmap layout without doing its own
-    // V8-internal symbol lookups. Frozen + defensively copied so the caller
-    // can't mutate it back into our internal state.
-    const processContextAttributes = Object.freeze({
+    return Object.freeze({
         'threadlocal.schema_version': SCHEMA_VERSION,
         'threadlocal.attribute_key_map': Object.freeze(keys.slice()),
         'threadlocal.wrapped_object_offset': WRAPPED_OBJECT_OFFSET,
         'threadlocal.tagged_size': TAGGED_SIZE,
     });
-
-    return {
-        buildContext,
-        // Sugar: build a context from `opts`, then enter / run / clear via
-        // the ThreadContext methods.
-        enterWithContext(opts) {
-            buildContext(opts).enter();
-        },
-        runWithContext(fn, opts) {
-            return buildContext(opts).run(fn);
-        },
-        clearContext() {
-            clearContext();
-        },
-        processContextAttributes,
-    };
 }
 
 exports.ThreadContext = ThreadContext;
 exports.getContext = getContext;
 exports.clearContext = clearContext;
-exports.makeNamedContext = makeNamedContext;
+exports.getProcessContextAttributes = getProcessContextAttributes;

--- a/js/index.js
+++ b/js/index.js
@@ -57,7 +57,7 @@ if (process.platform === 'linux') {
             throw new TypeError('options object required');
         }
         ensureHook();
-        return new addon.CtxWrap(
+        return new addon.ThreadContext(
             opts.traceId,
             opts.spanId,
             opts.attributes,
@@ -89,7 +89,7 @@ if (process.platform === 'linux') {
         if (!wrap) {
             throw new Error('no active thread context; call runWithContext or enterWithContext first');
         }
-        wrap.append(attributes);
+        wrap.appendAttributes(attributes);
     };
 
     isContextTruncated = function () {

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const SCHEMA_VERSION = 'nodejs_v1';
+const SCHEMA_VERSION = 'nodejs_v1_dev';
 
 // V8 layout constants the addon captured from the V8 headers Node bundles.
 // On non-Linux these fall back to the values matching Node's standard
@@ -163,8 +163,8 @@ function makeNamedContext(keys) {
     const processContextAttributes = Object.freeze({
         'threadlocal.schema_version': SCHEMA_VERSION,
         'threadlocal.attribute_key_map': Object.freeze(keys.slice()),
-        'threadlocal.nodejs_v1.wrapped_object_offset': WRAPPED_OBJECT_OFFSET,
-        'threadlocal.nodejs_v1.tagged_size': TAGGED_SIZE,
+        'threadlocal.wrapped_object_offset': WRAPPED_OBJECT_OFFSET,
+        'threadlocal.tagged_size': TAGGED_SIZE,
     });
 
     return {

--- a/js/index.js
+++ b/js/index.js
@@ -1,11 +1,5 @@
 'use strict';
 
-let runWithContext;
-let enterWithContext;
-let clearContext;
-let appendAttributes;
-let isContextTruncated;
-
 const SCHEMA_VERSION = 'nodejs_v1';
 
 // V8 layout constants the addon captured from the V8 headers Node bundles.
@@ -16,18 +10,26 @@ const SCHEMA_VERSION = 'nodejs_v1';
 let WRAPPED_OBJECT_OFFSET = 24;
 let TAGGED_SIZE = 8;
 
+// Public surface, populated by the Linux branch below. On other
+// platforms these stay as no-op stubs / a sham class.
+let ThreadContext;
+let getContext;
+let clearContext;
+
 if (process.platform === 'linux') {
     const bindings = require('bindings');
     const addon = bindings('customlabels');
     WRAPPED_OBJECT_OFFSET = addon.wrappedObjectOffset;
     TAGGED_SIZE = addon.taggedSize;
 
+    ThreadContext = addon.ThreadContext;
+
     const { AsyncLocalStorage } = require('node:async_hooks');
     let als;
 
     function asyncContextFrameError() {
         const [major] = process.versions.node.split('.').map(Number);
-        // If explicitly disabled, it's not in use.
+        // Explicit opt-out: it's not in use.
         if (process.execArgv.includes('--no-async-context-frame')) return 'Node explicitly launched with --no-async-context-frame';
         // Since Node 24, AsyncContextFrame is the default unless disabled.
         if (major >= 24) return undefined;
@@ -48,70 +50,64 @@ if (process.platform === 'linux') {
         addon.storeAls(als);
     }
 
-    function buildWrap(opts) {
-        if (!opts || typeof opts !== 'object') {
-            throw new TypeError('options object required');
-        }
-        ensureHook();
-        return new addon.ThreadContext(
-            opts.traceId,
-            opts.spanId,
-            opts.attributes,
-        );
-    }
-
-    runWithContext = function (fn, opts) {
-        const wrap = buildWrap(opts);
-        return als.run(wrap, fn);
+    getContext = function () {
+        return als ? als.getStore() : undefined;
     };
 
-    enterWithContext = function (opts) {
-        const wrap = buildWrap(opts);
-        als.enterWith(wrap);
-    };
-
+    // Idempotent: clearing when the hook hasn't been installed (no prior
+    // enter / run on a ThreadContext) is a no-op.
     clearContext = function () {
-        // Idempotent: clearing when no hook has been installed yet (and
-        // therefore no context can be active) is a no-op.
         if (!als) return;
         als.enterWith(undefined);
     };
 
-    appendAttributes = function (attributes) {
-        if (!als) {
-            throw new Error('no active thread context; call runWithContext or enterWithContext first');
-        }
-        const wrap = als.getStore();
-        if (!wrap) {
-            throw new Error('no active thread context; call runWithContext or enterWithContext first');
-        }
-        wrap.appendAttributes(attributes);
+    // Install the active-context channel on the ThreadContext prototype so
+    // the only way to push a ThreadContext into our AsyncLocalStorage is
+    // via the context itself — callers can't poison the ALS with an
+    // arbitrary object.
+    ThreadContext.prototype.enter = function () {
+        ensureHook();
+        als.enterWith(this);
     };
-
-    isContextTruncated = function () {
-        if (!als) return false;
-        const wrap = als.getStore();
-        if (!wrap) return false;
-        return wrap.isTruncated();
+    ThreadContext.prototype.run = function (fn) {
+        ensureHook();
+        return als.run(this, fn);
     };
 
     // Debug accessor (not part of the stable API; for tests / reader dev):
     // returns a Uint8Array view of the currently attached record, or undefined.
     exports._currentRecordBytes = function () {
-        if (!als) return undefined;
-        const wrap = als.getStore();
-        if (!wrap) return undefined;
-        return wrap.debugBytes();
+        const c = getContext();
+        return c ? c.debugBytes() : undefined;
     };
 } else {
-    runWithContext = function (fn, _opts) { return fn(); };
-    enterWithContext = function (_opts) {};
+    // Non-Linux degradation. The writer's reader contract is ELF-TLSDESC,
+    // meaningful only on Linux; on other platforms we still want the API
+    // to be callable so consumers don't have to gate every call site —
+    // construction succeeds but produces an inert context, and the
+    // enter/run/clearContext entry points don't wire anything into
+    // AsyncLocalStorage.
+    class NoopThreadContext {
+        appendAttributes() {}
+        isTruncated() { return false; }
+        debugBytes() { return new Uint8Array(0); }
+        enter() {}
+        run(fn) { return fn(); }
+    }
+    ThreadContext = NoopThreadContext;
+    getContext = function () { return undefined; };
     clearContext = function () {};
-    appendAttributes = function (_attributes) {};
-    isContextTruncated = function () { return false; };
     exports._currentRecordBytes = function () { return undefined; };
 }
 
+/**
+ * Build a name-addressed factory for ThreadContext. The supplied `keys`
+ * array is the same string list the caller publishes (or has published)
+ * as the `threadlocal.attribute_key_map` resource attribute in the
+ * OTEP-4719 process context: index N in this array is the uint8 key
+ * index N in the on-the-wire record. The mapping is captured once at
+ * factory time.
+ */
 function makeNamedContext(keys) {
     if (!Array.isArray(keys)) {
         throw new TypeError('keys must be an array of attribute names');
@@ -152,15 +148,11 @@ function makeNamedContext(keys) {
         return attributes;
     }
 
-    function toBaseOpts(opts) {
+    function buildContext(opts) {
         if (!opts || typeof opts !== 'object') {
             throw new TypeError('options object required');
         }
-        return {
-            traceId: opts.traceId,
-            spanId: opts.spanId,
-            attributes: resolveAttributes(opts.namedAttributes),
-        };
+        return new ThreadContext(opts.traceId, opts.spanId, resolveAttributes(opts.namedAttributes));
     }
 
     // Snapshot of the OTEP-4719 process-context attributes the caller should
@@ -176,28 +168,23 @@ function makeNamedContext(keys) {
     });
 
     return {
-        runWithContext(fn, opts) {
-            return runWithContext(fn, toBaseOpts(opts));
-        },
+        buildContext,
+        // Sugar: build a context from `opts`, then enter / run / clear via
+        // the ThreadContext methods.
         enterWithContext(opts) {
-            enterWithContext(toBaseOpts(opts));
+            buildContext(opts).enter();
+        },
+        runWithContext(fn, opts) {
+            return buildContext(opts).run(fn);
         },
         clearContext() {
             clearContext();
-        },
-        appendAttributes(namedAttributes) {
-            appendAttributes(resolveAttributes(namedAttributes));
-        },
-        isContextTruncated() {
-            return isContextTruncated();
         },
         processContextAttributes,
     };
 }
 
-exports.runWithContext = runWithContext;
-exports.enterWithContext = enterWithContext;
+exports.ThreadContext = ThreadContext;
+exports.getContext = getContext;
 exports.clearContext = clearContext;
-exports.appendAttributes = appendAttributes;
-exports.isContextTruncated = isContextTruncated;
 exports.makeNamedContext = makeNamedContext;

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let runWithContext;
 let enterWithContext;
 let clearContext;
@@ -16,34 +18,28 @@ let TAGGED_SIZE = 8;
 
 if (process.platform === 'linux') {
     const bindings = require('bindings');
-
     const addon = bindings('customlabels');
     WRAPPED_OBJECT_OFFSET = addon.wrappedObjectOffset;
     TAGGED_SIZE = addon.taggedSize;
 
     const { AsyncLocalStorage } = require('node:async_hooks');
-    let als = undefined;
+    let als;
 
     function asyncContextFrameError() {
         const [major] = process.versions.node.split('.').map(Number);
-
         // If explicitly disabled, it's not in use.
-        if (process.execArgv.includes('--no-async-context-frame')) return "Node explicitly launched with --no-async-context-frame";
-
+        if (process.execArgv.includes('--no-async-context-frame')) return 'Node explicitly launched with --no-async-context-frame';
         // Since Node 24, AsyncContextFrame is the default unless disabled.
         if (major >= 24) return undefined;
-
         // In Node 22/23, it existed behind an experimental flag.
         if (process.execArgv.includes('--experimental-async-context-frame')) return undefined;
-        if (major >= 22) return "Node versions prior to v24 must be launched with --experimental-async-context-frame";
-
+        if (major >= 22) return 'Node versions prior to v24 must be launched with --experimental-async-context-frame';
         // Older versions: not available.
-        return "Node major versions prior to v22 do not support the feature at all";
+        return 'Node major versions prior to v22 do not support the feature at all';
     }
 
     function ensureHook() {
-        if (als)
-            return;
+        if (als) return;
         const err = asyncContextFrameError();
         if (err) {
             throw new Error(`otel thread-ctx writer requires async_context_frame support, which is unavailable: ${err}.`);
@@ -135,7 +131,7 @@ function makeNamedContext(keys) {
     });
 
     function resolveAttributes(named) {
-        if (named == null) return undefined;
+        if (named === null || named === undefined) return undefined;
         const attributes = [];
         const set = (name, value) => {
             const idx = indexByName.get(name);

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -347,11 +347,11 @@ test('getProcessContextAttributes rejects non-string entries', () => {
     assert.throws(() => getProcessContextAttributes(['ok', 42]), /must be a string/);
 });
 
-test('enterWithContext attaches the record to the current async scope', () => {
+test('enterWithContext attaches the record to the current async scope', async () => {
     // Provide an outer scope so the enterWith attachment can't leak past
     // this test: when this outer runWithContext returns, the inner scope
     // (and anything enterWith did within it) is discarded.
-    tcRun(() => {
+    await tcRun(() => {
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, SPAN_ID_BYTES);
 
         const newSpan = bytesFromHex('aabbccddeeff0011');

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -36,17 +36,6 @@ const { spawnSync } = require('node:child_process');
 const lib = require('..');
 const { ThreadContext, getContext, clearContext, getProcessContextAttributes, _currentRecordBytes } = lib;
 
-// Helpers bridging the old positional-attrs test shape to the new
-// ThreadContext-first API.
-function tcRun(fn, opts) {
-    return new ThreadContext(opts.traceId, opts.spanId, opts.attributes).run(fn);
-}
-function tcEnter(opts) {
-    new ThreadContext(opts.traceId, opts.spanId, opts.attributes).enter();
-}
-function tcAppend(attributes) { getContext().appendAttributes(attributes); }
-function tcIsTruncated() { const c = getContext(); return c ? c.isTruncated() : false; }
-
 const TRACE_ID_BYTES = bytesFromHex('0102030405060708090a0b0c0d0e0f10');
 const SPAN_ID_BYTES  = bytesFromHex('1112131415161718');
 
@@ -88,9 +77,9 @@ function decodeAttrs(bytes) {
     return out;
 }
 
-function captureBytes(opts) {
+function captureBytes({ traceId, spanId, attributes } = {}) {
     let bytes;
-    tcRun(() => { bytes = _currentRecordBytes(); }, opts);
+    new ThreadContext(traceId, spanId, attributes).run(() => { bytes = _currentRecordBytes(); });
     return bytes;
 }
 
@@ -236,13 +225,9 @@ test('attrs sets past the 612-byte cap are truncated (entries past the limit dro
     const d = 'd'.repeat(30);
     let bytes;
     let truncated;
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES, [a, b, c, d]).run(() => {
         bytes = _currentRecordBytes();
-        truncated = tcIsTruncated();
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        attributes: [a, b, c, d],
+        truncated = getContext().isTruncated();
     });
     assert.deepEqual(decodeAttrs(bytes), [a, b, , d]);
     assert.equal(decodeHeader(bytes).attrsDataSize, 514 + 32);
@@ -266,39 +251,37 @@ test('non-array attributes argument is rejected', () => {
     }), /attributes must be an array/);
 });
 
-test('runWithContext returns fn result', () => {
-    const result = tcRun(() => 'ok', { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+test('ThreadContext.run returns fn result', () => {
+    const result = new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => 'ok');
     assert.equal(result, 'ok');
 });
 
-test('outside runWithContext, no active record', () => {
+test('outside a ThreadContext, no active record', () => {
     assert.equal(_currentRecordBytes(), undefined);
 });
 
-test('after runWithContext returns, no active record', () => {
-    tcRun(() => {}, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+test('after ThreadContext.run returns, no active record', () => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {});
     assert.equal(_currentRecordBytes(), undefined);
 });
 
-test('nested runWithContext restores parent context after inner returns', () => {
-    const outerOpts = { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES };
+test('nested ThreadContext.run restores parent context after inner returns', () => {
     const innerSpanBytes = bytesFromHex('aabbccddeeff0011');
-    const innerOpts = { traceId: TRACE_ID_BYTES, spanId: innerSpanBytes };
 
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         const outerBefore = decodeHeader(_currentRecordBytes()).spanId;
-        tcRun(() => {
+        new ThreadContext(TRACE_ID_BYTES, innerSpanBytes).run(() => {
             const inner = decodeHeader(_currentRecordBytes()).spanId;
             assert.deepEqual(inner, innerSpanBytes);
-        }, innerOpts);
+        });
         const outerAfter = decodeHeader(_currentRecordBytes()).spanId;
         assert.deepEqual(outerBefore, outerAfter);
         assert.deepEqual(outerAfter, SPAN_ID_BYTES);
-    }, outerOpts);
+    });
 });
 
-test('async work inside runWithContext sees same record after awaits', async () => {
-    await tcRun(async () => {
+test('async work inside ThreadContext.run sees same record after awaits', async () => {
+    await new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(async () => {
         const before = decodeHeader(_currentRecordBytes()).spanId;
         await Promise.resolve();
         const afterMicro = decodeHeader(_currentRecordBytes()).spanId;
@@ -307,22 +290,22 @@ test('async work inside runWithContext sees same record after awaits', async () 
         assert.deepEqual(before, SPAN_ID_BYTES);
         assert.deepEqual(afterMicro, SPAN_ID_BYTES);
         assert.deepEqual(afterMacro, SPAN_ID_BYTES);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
-test('concurrent async runWithContext calls keep contexts isolated', async () => {
+test('concurrent async ThreadContext.run calls keep contexts isolated', async () => {
     const aSpan = bytesFromHex('1111111111111111');
     const bSpan = bytesFromHex('2222222222222222');
 
     async function run(spanBytes) {
-        return tcRun(async () => {
+        return new ThreadContext(TRACE_ID_BYTES, spanBytes).run(async () => {
             const observed = [];
             for (let i = 0; i < 4; i++) {
                 observed.push(decodeHeader(_currentRecordBytes()).spanId);
                 await Promise.resolve();
             }
             return observed;
-        }, { traceId: TRACE_ID_BYTES, spanId: spanBytes });
+        });
     }
 
     const [aObs, bObs] = await Promise.all([run(aSpan), run(bSpan)]);
@@ -347,22 +330,22 @@ test('getProcessContextAttributes rejects non-string entries', () => {
     assert.throws(() => getProcessContextAttributes(['ok', 42]), /must be a string/);
 });
 
-test('enterWithContext attaches the record to the current async scope', async () => {
-    // Provide an outer scope so the enterWith attachment can't leak past
-    // this test: when this outer runWithContext returns, the inner scope
-    // (and anything enterWith did within it) is discarded.
-    await tcRun(() => {
+test('ThreadContext.enter attaches the record to the current async scope', async () => {
+    // Provide an outer scope so the enter() attachment can't leak past
+    // this test: when this outer run() returns, the inner scope (and
+    // anything enter() did within it) is discarded.
+    await new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, SPAN_ID_BYTES);
 
         const newSpan = bytesFromHex('aabbccddeeff0011');
-        tcEnter({ traceId: TRACE_ID_BYTES, spanId: newSpan });
+        new ThreadContext(TRACE_ID_BYTES, newSpan).enter();
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, newSpan);
 
         // Subsequent async work in the same scope still sees the new record.
         return Promise.resolve().then(() => {
             assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, newSpan);
         });
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 
     assert.equal(_currentRecordBytes(), undefined);
 });
@@ -402,74 +385,69 @@ test('getProcessContextAttributes is frozen and a defensive copy', () => {
 });
 
 test('clearContext detaches the active record within a scope', () => {
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         assert.ok(_currentRecordBytes());
         clearContext();
         assert.equal(_currentRecordBytes(), undefined);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
-test('after clearContext, getContext returns undefined and isContextTruncated is false', () => {
-    tcRun(() => {
+test('after clearContext, getContext returns undefined', () => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         assert.ok(getContext() !== undefined);
         clearContext();
         assert.equal(getContext(), undefined);
-        assert.equal(tcIsTruncated(), false);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
 test('clearContext is idempotent (calling twice or with no context is a no-op)', () => {
     // Outside any context — should not throw.
     clearContext();
     assert.equal(_currentRecordBytes(), undefined);
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         clearContext();
         clearContext();
         assert.equal(_currentRecordBytes(), undefined);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
-test('runWithContext re-establishes a record after a clearContext', () => {
-    tcRun(() => {
+test('ThreadContext.run re-establishes a record after a clearContext', () => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         clearContext();
         const innerSpan = bytesFromHex('aabbccddeeff0011');
-        tcRun(() => {
+        new ThreadContext(TRACE_ID_BYTES, innerSpan).run(() => {
             assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, innerSpan);
-        }, { traceId: TRACE_ID_BYTES, spanId: innerSpan });
-        // After the inner runWithContext returns, we're back to the
-        // post-clear state in the outer scope: no active record.
+        });
+        // After the inner run() returns, we're back to the post-clear state
+        // in the outer scope: no active record.
         assert.equal(_currentRecordBytes(), undefined);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
-test('enterWithContext re-establishes a record after a clearContext', () => {
-    tcRun(() => {
+test('ThreadContext.enter re-establishes a record after a clearContext', () => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         clearContext();
         const newSpan = bytesFromHex('aabbccddeeff0011');
-        tcEnter({ traceId: TRACE_ID_BYTES, spanId: newSpan });
+        new ThreadContext(TRACE_ID_BYTES, newSpan).enter();
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, newSpan);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
 test('appendAttributes adds entries to the current record', () => {
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES, ['GET']).run(() => {
         assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['GET']);
-        tcAppend([, , '200']);
+        getContext().appendAttributes([, , '200']);
         assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['GET', , '200']);
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        attributes: ['GET'],
     });
 });
 
 test('appendAttributes is in-place when bytes fit in the slack', () => {
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES, ['xxx']).run(() => {
         // Initial allocation has at least 64 bytes of attrs_data capacity;
         // one "xxx" entry occupies 5. An append of "ab" (4 bytes encoded)
         // fits in the slack, so the append takes the in-place path.
         const before = _currentRecordBytes();
-        tcAppend([, 'ab']);
+        getContext().appendAttributes([, 'ab']);
         const after = _currentRecordBytes();
         assert.deepEqual(decodeAttrs(after), ['xxx', 'ab']);
         assert.equal(after.length, before.length + 2 + 2);
@@ -483,15 +461,11 @@ test('appendAttributes is in-place when bytes fit in the slack', () => {
         assert.deepEqual(after.slice(0, 26), before.slice(0, 26));
         assert.deepEqual(after.slice(28, 33), before.slice(28, 33));
         assert.equal(after[24], 1);  // valid restored to 1 after the dance
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        attributes: ['xxx'],
     });
 });
 
 test('appendAttributes grows the record geometrically when slack runs out', () => {
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         // Append 8 × 60-byte values. Each encodes to 62 bytes; 8 of them =
         // 496 bytes total. The initial 64-byte capacity is exhausted quickly;
         // the buffer doubles (64 → 128 → 256 → 512) and ends up with all
@@ -500,97 +474,83 @@ test('appendAttributes grows the record geometrically when slack runs out', () =
         for (let i = 0; i < 8; i++) {
             const append = [];
             append[i] = v;
-            tcAppend(append);
+            getContext().appendAttributes(append);
         }
         const decoded = decodeAttrs(_currentRecordBytes());
         for (let i = 0; i < 8; i++) {
             assert.equal(decoded[i], v, `slot ${i}`);
         }
         assert.equal(decodeHeader(_currentRecordBytes()).attrsDataSize, 8 * 62);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
 test('appendAttributes is a no-op when given an empty array', () => {
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         const before = _currentRecordBytes();
-        tcAppend([]);
+        getContext().appendAttributes([]);
         const after = _currentRecordBytes();
         assert.deepEqual(after, before);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
 test('appendAttributes is a no-op when all slots are null/undefined', () => {
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
         const before = _currentRecordBytes();
-        tcAppend([null, undefined, , null]);
+        getContext().appendAttributes([null, undefined, , null]);
         const after = _currentRecordBytes();
         assert.deepEqual(after, before);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    });
 });
 
 test('appendAttributes silently drops entries past the 612-byte cap and sets the truncated flag', () => {
     const big = 'a'.repeat(255); // 257 bytes encoded
-    tcRun(() => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES).run(() => {
+        const ctx = getContext();
         // 2 × 257 = 514 bytes, all fit.
-        tcAppend([big, big]);
-        assert.equal(tcIsTruncated(), false);
+        ctx.appendAttributes([big, big]);
+        assert.equal(ctx.isTruncated(), false);
         // A third 257-byte entry would push to 771 — drops, flag flips.
-        tcAppend([, , big]);
-        assert.equal(tcIsTruncated(), true);
+        ctx.appendAttributes([, , big]);
+        assert.equal(ctx.isTruncated(), true);
         assert.equal(decodeHeader(_currentRecordBytes()).attrsDataSize, 514);
         // A subsequent small entry (e.g. 30 bytes) still fits and is kept;
         // skip-and-continue applies to per-call as well as per-record-cap.
         const small = 'x'.repeat(30);
-        tcAppend([, , , small]);
+        ctx.appendAttributes([, , , small]);
         const decoded = decodeAttrs(_currentRecordBytes());
         assert.equal(decoded[0], big);
         assert.equal(decoded[1], big);
         assert.equal(decoded[2], undefined);
         assert.equal(decoded[3], small);
         // Flag stays true.
-        assert.equal(tcIsTruncated(), true);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+        assert.equal(ctx.isTruncated(), true);
+    });
 });
 
-test('isContextTruncated returns false outside a context', () => {
-    assert.equal(tcIsTruncated(), false);
-});
-
-test('isContextTruncated returns false for a non-truncated record', () => {
-    tcRun(() => {
-        assert.equal(tcIsTruncated(), false);
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        attributes: ['GET', '/x'],
+test('isTruncated returns false for a non-truncated record', () => {
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES, ['GET', '/x']).run(() => {
+        assert.equal(getContext().isTruncated(), false);
     });
 });
 
 test('isTruncated reflects appended-then-overflowed entries', () => {
-    tcRun(() => {
-        assert.equal(tcIsTruncated(), false);
-        tcAppend([, , 'c'.repeat(255), , , 'd'.repeat(255), , , 'e'.repeat(255)]);
+    new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES, ['a', 'b']).run(() => {
+        const ctx = getContext();
+        assert.equal(ctx.isTruncated(), false);
+        ctx.appendAttributes([, , 'c'.repeat(255), , , 'd'.repeat(255), , , 'e'.repeat(255)]);
         // Three 257-byte appends past the existing ~2 bytes = 771 > 612.
         // At least one must have been dropped.
-        assert.equal(tcIsTruncated(), true);
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        attributes: ['a', 'b'],
+        assert.equal(ctx.isTruncated(), true);
     });
 });
 
 test('appendAttributes propagates through async continuations', async () => {
-    await tcRun(async () => {
-        tcAppend([, 'after-await']);
+    await new ThreadContext(TRACE_ID_BYTES, SPAN_ID_BYTES, ['before']).run(async () => {
+        getContext().appendAttributes([, 'after-await']);
         await Promise.resolve();
         // After await, the same wrapper is still in the ALS, and append's
         // effect is observable.
         assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['before', 'after-await']);
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        attributes: ['before'],
     });
 });
 
@@ -618,4 +578,3 @@ test('otel_thread_ctx_nodejs_v1 is exported as a TLS dynsym', (t) => {
     assert.match(line, /\bGLOBAL\b/, `expected GLOBAL binding, got: ${line.trim()}`);
     assert.match(line, /\bDEFAULT\b/, `expected DEFAULT visibility, got: ${line.trim()}`);
 });
-

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -432,17 +432,17 @@ test('makeNamedContext exposes processContextAttributes matching the input keys'
     const keys = ['http.method', 'http.route', 'user.id'];
     const named = makeNamedContext(keys);
     const pca = named.processContextAttributes;
-    assert.equal(pca['threadlocal.schema_version'], 'nodejs_v1');
+    assert.equal(pca['threadlocal.schema_version'], 'nodejs_v1_dev');
     assert.deepEqual(pca['threadlocal.attribute_key_map'], keys);
     // V8 layout constants — on Node's standard build (no pointer
     // compression, no sandbox) these are 24 and 8 respectively.
-    assert.equal(pca['threadlocal.nodejs_v1.wrapped_object_offset'], 24);
-    assert.equal(pca['threadlocal.nodejs_v1.tagged_size'], 8);
+    assert.equal(pca['threadlocal.wrapped_object_offset'], 24);
+    assert.equal(pca['threadlocal.tagged_size'], 8);
     assert.deepEqual(Object.keys(pca).sort(), [
         'threadlocal.attribute_key_map',
-        'threadlocal.nodejs_v1.tagged_size',
-        'threadlocal.nodejs_v1.wrapped_object_offset',
         'threadlocal.schema_version',
+        'threadlocal.tagged_size',
+        'threadlocal.wrapped_object_offset',
     ]);
 });
 

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -34,7 +34,18 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const lib = require('..');
-const { runWithContext, enterWithContext, clearContext, appendAttributes, isContextTruncated, makeNamedContext, _currentRecordBytes } = lib;
+const { ThreadContext, getContext, clearContext, makeNamedContext, _currentRecordBytes } = lib;
+
+// Helpers bridging the old positional-attrs test shape to the new
+// ThreadContext-first API.
+function tcRun(fn, opts) {
+    return new ThreadContext(opts.traceId, opts.spanId, opts.attributes).run(fn);
+}
+function tcEnter(opts) {
+    new ThreadContext(opts.traceId, opts.spanId, opts.attributes).enter();
+}
+function tcAppend(attributes) { getContext().appendAttributes(attributes); }
+function tcIsTruncated() { const c = getContext(); return c ? c.isTruncated() : false; }
 
 const TRACE_ID_BYTES = bytesFromHex('0102030405060708090a0b0c0d0e0f10');
 const SPAN_ID_BYTES  = bytesFromHex('1112131415161718');
@@ -79,7 +90,7 @@ function decodeAttrs(bytes) {
 
 function captureBytes(opts) {
     let bytes;
-    runWithContext(() => { bytes = _currentRecordBytes(); }, opts);
+    tcRun(() => { bytes = _currentRecordBytes(); }, opts);
     return bytes;
 }
 
@@ -225,9 +236,9 @@ test('attrs sets past the 612-byte cap are truncated (entries past the limit dro
     const d = 'd'.repeat(30);
     let bytes;
     let truncated;
-    runWithContext(() => {
+    tcRun(() => {
         bytes = _currentRecordBytes();
-        truncated = isContextTruncated();
+        truncated = tcIsTruncated();
     }, {
         traceId: TRACE_ID_BYTES,
         spanId:  SPAN_ID_BYTES,
@@ -256,7 +267,7 @@ test('non-array attributes argument is rejected', () => {
 });
 
 test('runWithContext returns fn result', () => {
-    const result = runWithContext(() => 'ok', { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    const result = tcRun(() => 'ok', { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
     assert.equal(result, 'ok');
 });
 
@@ -265,7 +276,7 @@ test('outside runWithContext, no active record', () => {
 });
 
 test('after runWithContext returns, no active record', () => {
-    runWithContext(() => {}, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
+    tcRun(() => {}, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
     assert.equal(_currentRecordBytes(), undefined);
 });
 
@@ -274,9 +285,9 @@ test('nested runWithContext restores parent context after inner returns', () => 
     const innerSpanBytes = bytesFromHex('aabbccddeeff0011');
     const innerOpts = { traceId: TRACE_ID_BYTES, spanId: innerSpanBytes };
 
-    runWithContext(() => {
+    tcRun(() => {
         const outerBefore = decodeHeader(_currentRecordBytes()).spanId;
-        runWithContext(() => {
+        tcRun(() => {
             const inner = decodeHeader(_currentRecordBytes()).spanId;
             assert.deepEqual(inner, innerSpanBytes);
         }, innerOpts);
@@ -287,7 +298,7 @@ test('nested runWithContext restores parent context after inner returns', () => 
 });
 
 test('async work inside runWithContext sees same record after awaits', async () => {
-    await runWithContext(async () => {
+    await tcRun(async () => {
         const before = decodeHeader(_currentRecordBytes()).spanId;
         await Promise.resolve();
         const afterMicro = decodeHeader(_currentRecordBytes()).spanId;
@@ -304,7 +315,7 @@ test('concurrent async runWithContext calls keep contexts isolated', async () =>
     const bSpan = bytesFromHex('2222222222222222');
 
     async function run(spanBytes) {
-        return runWithContext(async () => {
+        return tcRun(async () => {
             const observed = [];
             for (let i = 0; i < 4; i++) {
                 observed.push(decodeHeader(_currentRecordBytes()).spanId);
@@ -393,11 +404,11 @@ test('enterWithContext attaches the record to the current async scope', () => {
     // Provide an outer scope so the enterWith attachment can't leak past
     // this test: when this outer runWithContext returns, the inner scope
     // (and anything enterWith did within it) is discarded.
-    runWithContext(() => {
+    tcRun(() => {
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, SPAN_ID_BYTES);
 
         const newSpan = bytesFromHex('aabbccddeeff0011');
-        enterWithContext({ traceId: TRACE_ID_BYTES, spanId: newSpan });
+        tcEnter({ traceId: TRACE_ID_BYTES, spanId: newSpan });
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, newSpan);
 
         // Subsequent async work in the same scope still sees the new record.
@@ -409,14 +420,12 @@ test('enterWithContext attaches the record to the current async scope', () => {
     assert.equal(_currentRecordBytes(), undefined);
 });
 
-test('enterWithContext requires an options object', () => {
-    assert.throws(() => enterWithContext(undefined), /options object required/);
-});
-
-test('makeNamedContext returns an object with both methods', () => {
+test('makeNamedContext returns an object exposing buildContext + sugar', () => {
     const named = makeNamedContext(['a']);
+    assert.equal(typeof named.buildContext, 'function');
     assert.equal(typeof named.runWithContext, 'function');
     assert.equal(typeof named.enterWithContext, 'function');
+    assert.equal(typeof named.clearContext, 'function');
 });
 
 test('makeNamedContext exposes processContextAttributes matching the input keys', () => {
@@ -457,7 +466,7 @@ test('processContextAttributes is frozen and a defensive copy', () => {
 
 test('named.enterWithContext attaches a name-addressed record', () => {
     const named = makeNamedContext(['route']);
-    runWithContext(() => {
+    tcRun(() => {
         named.enterWithContext({
             traceId: TRACE_ID_BYTES,
             spanId:  SPAN_ID_BYTES,
@@ -468,18 +477,19 @@ test('named.enterWithContext attaches a name-addressed record', () => {
 });
 
 test('clearContext detaches the active record within a scope', () => {
-    runWithContext(() => {
+    tcRun(() => {
         assert.ok(_currentRecordBytes());
         clearContext();
         assert.equal(_currentRecordBytes(), undefined);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
 
-test('after clearContext, appendAttributes throws and isContextTruncated is false', () => {
-    runWithContext(() => {
+test('after clearContext, getContext returns undefined and isContextTruncated is false', () => {
+    tcRun(() => {
+        assert.ok(getContext() !== undefined);
         clearContext();
-        assert.throws(() => appendAttributes(['v']), /no active thread context/);
-        assert.equal(isContextTruncated(), false);
+        assert.equal(getContext(), undefined);
+        assert.equal(tcIsTruncated(), false);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
 
@@ -487,7 +497,7 @@ test('clearContext is idempotent (calling twice or with no context is a no-op)',
     // Outside any context — should not throw.
     clearContext();
     assert.equal(_currentRecordBytes(), undefined);
-    runWithContext(() => {
+    tcRun(() => {
         clearContext();
         clearContext();
         assert.equal(_currentRecordBytes(), undefined);
@@ -495,10 +505,10 @@ test('clearContext is idempotent (calling twice or with no context is a no-op)',
 });
 
 test('runWithContext re-establishes a record after a clearContext', () => {
-    runWithContext(() => {
+    tcRun(() => {
         clearContext();
         const innerSpan = bytesFromHex('aabbccddeeff0011');
-        runWithContext(() => {
+        tcRun(() => {
             assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, innerSpan);
         }, { traceId: TRACE_ID_BYTES, spanId: innerSpan });
         // After the inner runWithContext returns, we're back to the
@@ -508,10 +518,10 @@ test('runWithContext re-establishes a record after a clearContext', () => {
 });
 
 test('enterWithContext re-establishes a record after a clearContext', () => {
-    runWithContext(() => {
+    tcRun(() => {
         clearContext();
         const newSpan = bytesFromHex('aabbccddeeff0011');
-        enterWithContext({ traceId: TRACE_ID_BYTES, spanId: newSpan });
+        tcEnter({ traceId: TRACE_ID_BYTES, spanId: newSpan });
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, newSpan);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
@@ -530,9 +540,9 @@ test('named.clearContext detaches the active record', () => {
 });
 
 test('appendAttributes adds entries to the current record', () => {
-    runWithContext(() => {
+    tcRun(() => {
         assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['GET']);
-        appendAttributes([, , '200']);
+        tcAppend([, , '200']);
         assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['GET', , '200']);
     }, {
         traceId: TRACE_ID_BYTES,
@@ -542,12 +552,12 @@ test('appendAttributes adds entries to the current record', () => {
 });
 
 test('appendAttributes is in-place when bytes fit in the slack', () => {
-    runWithContext(() => {
+    tcRun(() => {
         // Initial allocation has at least 64 bytes of attrs_data capacity;
         // one "xxx" entry occupies 5. An append of "ab" (4 bytes encoded)
         // fits in the slack, so the append takes the in-place path.
         const before = _currentRecordBytes();
-        appendAttributes([, 'ab']);
+        tcAppend([, 'ab']);
         const after = _currentRecordBytes();
         assert.deepEqual(decodeAttrs(after), ['xxx', 'ab']);
         assert.equal(after.length, before.length + 2 + 2);
@@ -569,7 +579,7 @@ test('appendAttributes is in-place when bytes fit in the slack', () => {
 });
 
 test('appendAttributes grows the record geometrically when slack runs out', () => {
-    runWithContext(() => {
+    tcRun(() => {
         // Append 8 × 60-byte values. Each encodes to 62 bytes; 8 of them =
         // 496 bytes total. The initial 64-byte capacity is exhausted quickly;
         // the buffer doubles (64 → 128 → 256 → 512) and ends up with all
@@ -578,7 +588,7 @@ test('appendAttributes grows the record geometrically when slack runs out', () =
         for (let i = 0; i < 8; i++) {
             const append = [];
             append[i] = v;
-            appendAttributes(append);
+            tcAppend(append);
         }
         const decoded = decodeAttrs(_currentRecordBytes());
         for (let i = 0; i < 8; i++) {
@@ -588,23 +598,19 @@ test('appendAttributes grows the record geometrically when slack runs out', () =
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
 
-test('appendAttributes throws when there is no current context', () => {
-    assert.throws(() => appendAttributes(['v']), /no active thread context/);
-});
-
 test('appendAttributes is a no-op when given an empty array', () => {
-    runWithContext(() => {
+    tcRun(() => {
         const before = _currentRecordBytes();
-        appendAttributes([]);
+        tcAppend([]);
         const after = _currentRecordBytes();
         assert.deepEqual(after, before);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
 
 test('appendAttributes is a no-op when all slots are null/undefined', () => {
-    runWithContext(() => {
+    tcRun(() => {
         const before = _currentRecordBytes();
-        appendAttributes([null, undefined, , null]);
+        tcAppend([null, undefined, , null]);
         const after = _currentRecordBytes();
         assert.deepEqual(after, before);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
@@ -612,35 +618,35 @@ test('appendAttributes is a no-op when all slots are null/undefined', () => {
 
 test('appendAttributes silently drops entries past the 612-byte cap and sets the truncated flag', () => {
     const big = 'a'.repeat(255); // 257 bytes encoded
-    runWithContext(() => {
+    tcRun(() => {
         // 2 × 257 = 514 bytes, all fit.
-        appendAttributes([big, big]);
-        assert.equal(isContextTruncated(), false);
+        tcAppend([big, big]);
+        assert.equal(tcIsTruncated(), false);
         // A third 257-byte entry would push to 771 — drops, flag flips.
-        appendAttributes([, , big]);
-        assert.equal(isContextTruncated(), true);
+        tcAppend([, , big]);
+        assert.equal(tcIsTruncated(), true);
         assert.equal(decodeHeader(_currentRecordBytes()).attrsDataSize, 514);
         // A subsequent small entry (e.g. 30 bytes) still fits and is kept;
         // skip-and-continue applies to per-call as well as per-record-cap.
         const small = 'x'.repeat(30);
-        appendAttributes([, , , small]);
+        tcAppend([, , , small]);
         const decoded = decodeAttrs(_currentRecordBytes());
         assert.equal(decoded[0], big);
         assert.equal(decoded[1], big);
         assert.equal(decoded[2], undefined);
         assert.equal(decoded[3], small);
         // Flag stays true.
-        assert.equal(isContextTruncated(), true);
+        assert.equal(tcIsTruncated(), true);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
 
 test('isContextTruncated returns false outside a context', () => {
-    assert.equal(isContextTruncated(), false);
+    assert.equal(tcIsTruncated(), false);
 });
 
 test('isContextTruncated returns false for a non-truncated record', () => {
-    runWithContext(() => {
-        assert.equal(isContextTruncated(), false);
+    tcRun(() => {
+        assert.equal(tcIsTruncated(), false);
     }, {
         traceId: TRACE_ID_BYTES,
         spanId:  SPAN_ID_BYTES,
@@ -648,14 +654,14 @@ test('isContextTruncated returns false for a non-truncated record', () => {
     });
 });
 
-test('named context exposes isContextTruncated mirroring the top-level one', () => {
+test('isTruncated reflects appended-then-overflowed entries', () => {
     const named = makeNamedContext(['a', 'b', 'c']);
     named.runWithContext(() => {
-        assert.equal(named.isContextTruncated(), false);
-        appendAttributes([, , 'c'.repeat(255), , , 'd'.repeat(255), , , 'e'.repeat(255)]);
+        assert.equal(tcIsTruncated(), false);
+        tcAppend([, , 'c'.repeat(255), , , 'd'.repeat(255), , , 'e'.repeat(255)]);
         // Three 257-byte appends past the existing ~2 bytes = 771 > 612.
         // At least one must have been dropped.
-        assert.equal(named.isContextTruncated(), true);
+        assert.equal(tcIsTruncated(), true);
     }, {
         traceId: TRACE_ID_BYTES,
         spanId:  SPAN_ID_BYTES,
@@ -664,8 +670,8 @@ test('named context exposes isContextTruncated mirroring the top-level one', () 
 });
 
 test('appendAttributes propagates through async continuations', async () => {
-    await runWithContext(async () => {
-        appendAttributes([, 'after-await']);
+    await tcRun(async () => {
+        tcAppend([, 'after-await']);
         await Promise.resolve();
         // After await, the same wrapper is still in the ALS, and append's
         // effect is observable.
@@ -677,30 +683,16 @@ test('appendAttributes propagates through async continuations', async () => {
     });
 });
 
-test('named.appendAttributes appends by name', () => {
-    const named = makeNamedContext(['http.method', 'http.route', 'http.status']);
-    named.runWithContext(() => {
-        named.appendAttributes({ 'http.status': '500' });
-        assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['GET', '/x', '500']);
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: { 'http.method': 'GET', 'http.route': '/x' },
-    });
-});
-
-test('named.appendAttributes rejects unknown names', () => {
+test('buildContext rejects unknown names', () => {
     const named = makeNamedContext(['known']);
-    named.runWithContext(() => {
-        assert.throws(
-            () => named.appendAttributes({ unknown: 'v' }),
-            /unknown attribute name: unknown/,
-        );
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: { known: 'k' },
-    });
+    assert.throws(
+        () => named.buildContext({
+            traceId: TRACE_ID_BYTES,
+            spanId:  SPAN_ID_BYTES,
+            namedAttributes: { unknown: 'v' },
+        }),
+        /unknown attribute name: unknown/,
+    );
 });
 
 test('otel_thread_ctx_nodejs_v1 is exported as a TLS dynsym', (t) => {

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -34,7 +34,7 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const lib = require('..');
-const { ThreadContext, getContext, clearContext, makeNamedContext, _currentRecordBytes } = lib;
+const { ThreadContext, getContext, clearContext, getProcessContextAttributes, _currentRecordBytes } = lib;
 
 // Helpers bridging the old positional-attrs test shape to the new
 // ThreadContext-first API.
@@ -330,74 +330,21 @@ test('concurrent async runWithContext calls keep contexts isolated', async () =>
     for (const s of bObs) assert.deepEqual(s, bSpan);
 });
 
-test('makeNamedContext rejects non-array keys', () => {
-    assert.throws(() => makeNamedContext({}), /must be an array/);
+test('getProcessContextAttributes rejects non-array keys', () => {
+    assert.throws(() => getProcessContextAttributes({}), /must be an array/);
 });
 
-test('makeNamedContext rejects more than 256 keys', () => {
+test('getProcessContextAttributes rejects more than 256 keys', () => {
     const tooMany = Array.from({ length: 257 }, (_, i) => `k${i}`);
-    assert.throws(() => makeNamedContext(tooMany), /exceeds 256/);
+    assert.throws(() => getProcessContextAttributes(tooMany), /exceeds 256/);
 });
 
-test('makeNamedContext rejects duplicate names', () => {
-    assert.throws(() => makeNamedContext(['x', 'y', 'x']), /duplicate key name/);
+test('getProcessContextAttributes rejects duplicate names', () => {
+    assert.throws(() => getProcessContextAttributes(['x', 'y', 'x']), /duplicate key name/);
 });
 
-test('makeNamedContext rejects non-string entries', () => {
-    assert.throws(() => makeNamedContext(['ok', 42]), /must be a string/);
-});
-
-test('namedAttributes (object form) resolves to indices', () => {
-    const named = makeNamedContext(['http.method', 'http.route']);
-    let bytes;
-    named.runWithContext(() => { bytes = _currentRecordBytes(); }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: { 'http.method': 'GET', 'http.route': '/x' },
-    });
-    assert.deepEqual(decodeAttrs(bytes), ['GET', '/x']);
-});
-
-test('namedAttributes (Map form) resolves to indices', () => {
-    const named = makeNamedContext(['a', 'b']);
-    let bytes;
-    named.runWithContext(() => { bytes = _currentRecordBytes(); }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: new Map([['a', 'A'], ['b', 'B']]),
-    });
-    assert.deepEqual(decodeAttrs(bytes), ['A', 'B']);
-});
-
-test('namedAttributes (array form) resolves to indices', () => {
-    const named = makeNamedContext(['a', 'b']);
-    let bytes;
-    named.runWithContext(() => { bytes = _currentRecordBytes(); }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: [['a', 'A'], ['b', 'B']],
-    });
-    assert.deepEqual(decodeAttrs(bytes), ['A', 'B']);
-});
-
-test('unknown name in namedAttributes is rejected', () => {
-    const named = makeNamedContext(['a']);
-    assert.throws(() => named.runWithContext(() => {}, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: { unknown: 'v' },
-    }), /unknown attribute name: unknown/);
-});
-
-test('namedAttributes coerces non-string values', () => {
-    const named = makeNamedContext(['n']);
-    let bytes;
-    named.runWithContext(() => { bytes = _currentRecordBytes(); }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: { n: 7 },
-    });
-    assert.deepEqual(decodeAttrs(bytes), ['7']);
+test('getProcessContextAttributes rejects non-string entries', () => {
+    assert.throws(() => getProcessContextAttributes(['ok', 42]), /must be a string/);
 });
 
 test('enterWithContext attaches the record to the current async scope', () => {
@@ -420,18 +367,9 @@ test('enterWithContext attaches the record to the current async scope', () => {
     assert.equal(_currentRecordBytes(), undefined);
 });
 
-test('makeNamedContext returns an object exposing buildContext + sugar', () => {
-    const named = makeNamedContext(['a']);
-    assert.equal(typeof named.buildContext, 'function');
-    assert.equal(typeof named.runWithContext, 'function');
-    assert.equal(typeof named.enterWithContext, 'function');
-    assert.equal(typeof named.clearContext, 'function');
-});
-
-test('makeNamedContext exposes processContextAttributes matching the input keys', () => {
+test('getProcessContextAttributes returns the expected shape', () => {
     const keys = ['http.method', 'http.route', 'user.id'];
-    const named = makeNamedContext(keys);
-    const pca = named.processContextAttributes;
+    const pca = getProcessContextAttributes(keys);
     assert.equal(pca['threadlocal.schema_version'], 'nodejs_v1_dev');
     assert.deepEqual(pca['threadlocal.attribute_key_map'], keys);
     // V8 layout constants — on Node's standard build (no pointer
@@ -446,10 +384,9 @@ test('makeNamedContext exposes processContextAttributes matching the input keys'
     ]);
 });
 
-test('processContextAttributes is frozen and a defensive copy', () => {
+test('getProcessContextAttributes is frozen and a defensive copy', () => {
     const keys = ['http.method', 'http.route'];
-    const named = makeNamedContext(keys);
-    const pca = named.processContextAttributes;
+    const pca = getProcessContextAttributes(keys);
     assert.ok(Object.isFrozen(pca));
     assert.ok(Object.isFrozen(pca['threadlocal.attribute_key_map']));
 
@@ -462,18 +399,6 @@ test('processContextAttributes is frozen and a defensive copy', () => {
     assert.throws(() => {
         pca['threadlocal.schema_version'] = 'tampered';
     }, /read-only|read only|TypeError/i);
-});
-
-test('named.enterWithContext attaches a name-addressed record', () => {
-    const named = makeNamedContext(['route']);
-    tcRun(() => {
-        named.enterWithContext({
-            traceId: TRACE_ID_BYTES,
-            spanId:  SPAN_ID_BYTES,
-            namedAttributes: { route: '/x' },
-        });
-        assert.deepEqual(decodeAttrs(_currentRecordBytes()), ['/x']);
-    }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
 });
 
 test('clearContext detaches the active record within a scope', () => {
@@ -524,19 +449,6 @@ test('enterWithContext re-establishes a record after a clearContext', () => {
         tcEnter({ traceId: TRACE_ID_BYTES, spanId: newSpan });
         assert.deepEqual(decodeHeader(_currentRecordBytes()).spanId, newSpan);
     }, { traceId: TRACE_ID_BYTES, spanId: SPAN_ID_BYTES });
-});
-
-test('named.clearContext detaches the active record', () => {
-    const named = makeNamedContext(['route']);
-    named.runWithContext(() => {
-        assert.ok(_currentRecordBytes());
-        named.clearContext();
-        assert.equal(_currentRecordBytes(), undefined);
-    }, {
-        traceId: TRACE_ID_BYTES,
-        spanId:  SPAN_ID_BYTES,
-        namedAttributes: { route: '/x' },
-    });
 });
 
 test('appendAttributes adds entries to the current record', () => {
@@ -655,8 +567,7 @@ test('isContextTruncated returns false for a non-truncated record', () => {
 });
 
 test('isTruncated reflects appended-then-overflowed entries', () => {
-    const named = makeNamedContext(['a', 'b', 'c']);
-    named.runWithContext(() => {
+    tcRun(() => {
         assert.equal(tcIsTruncated(), false);
         tcAppend([, , 'c'.repeat(255), , , 'd'.repeat(255), , , 'e'.repeat(255)]);
         // Three 257-byte appends past the existing ~2 bytes = 771 > 612.
@@ -665,7 +576,7 @@ test('isTruncated reflects appended-then-overflowed entries', () => {
     }, {
         traceId: TRACE_ID_BYTES,
         spanId:  SPAN_ID_BYTES,
-        namedAttributes: { a: 'a', b: 'b' },
+        attributes: ['a', 'b'],
     });
 });
 
@@ -681,18 +592,6 @@ test('appendAttributes propagates through async continuations', async () => {
         spanId:  SPAN_ID_BYTES,
         attributes: ['before'],
     });
-});
-
-test('buildContext rejects unknown names', () => {
-    const named = makeNamedContext(['known']);
-    assert.throws(
-        () => named.buildContext({
-            traceId: TRACE_ID_BYTES,
-            spanId:  SPAN_ID_BYTES,
-            namedAttributes: { unknown: 'v' },
-        }),
-        /unknown attribute name: unknown/,
-    );
 });
 
 test('otel_thread_ctx_nodejs_v1 is exported as a TLS dynsym', (t) => {


### PR DESCRIPTION
## Summary

As part of reviews, and actually attempting to integrate this code with a tracer library, I arrived at some changes.

- I renamed `CtxWrap` to `ThreadContext` in the JS API. The former name alluded to an implementation detail of how native data is exposed to JS instead of what it is, I think this is much clearer.
- Most significantly, I also reshaped the JS API around explicitly-allocated instances of `ThreadContext` class. Basically, I separated allocation from activation. I dropped the implicit-storage helpers so integrators can use one record per span and activate that record when the span becomes active without per-enter allocation. This also allows attributes previously appended to be preserved as the identity of the record remains stable. makeNamedContext proved to be mostly dead weight with explicit instances, so I dropped it and just preserved the process context attributes getter as a top-level function. These changes were informed by an actual attempt to integrate this API with a tracer library (to paraphrase, no planned API survives contact with integration.)
- Updated README + `.d.ts` for the new API surface.

There are also two minor issues addressed:
- Following some discussions, we renamed the schema-version string to `nodejs_v1_dev` for the time being and also
-  dropped the `nodejs_v1` namespace from the threadlocal layout attribute keys (`threadlocal.wrapped_object_offset`, `threadlocal.tagged_size`.) Since the schema name already determines the attribute set, having extra namespacing is unnecessary and would also raise an issue of what to do with the extra namespace if the schema version or name changes.

Finally, there's some code formatting changes in their own commits:
- I adopted a `.clang-format` with what is basically Google code style and run it on `js/addon.cpp`, plus dropped two unused `using v8::…` declarations.
- I brought `index.js` stylistically in-line with how we usually format JS code (single quotes, no explicit undefined assignments on declaration, `===` instead of `==`, `use strict` on top) 

## Test plan
- [ ] `cd js && npm test` on Linux (AsyncContextFrame branch)
- [ ] Same suite on macOS / Windows (no-op platform branches)
- [ ] Verify the dd-trace-js and pprof-nodejs vendored copies still build against this API