### PR TITLE
Publish V8 + ObjectWrap layout constants for readers

### DIFF
--- a/js/addon.cpp
+++ b/js/addon.cpp
@@ -668,22 +668,46 @@ constexpr int WRAPPED_OBJECT_OFFSET = 0;
 #endif
 constexpr int TAGGED_SIZE = v8::internal::kApiTaggedSize;
 
+// sizeof(node::ObjectWrap). Given a pointer to a CtxWrap — or any other
+// ObjectWrap-derived C++ object attached to a JSObject via the V8
+// wrapped-object slot — add this offset to reach the derived class's own
+// fields. For CtxWrap, that's `record_` (see the static_assert on its
+// offset above).
+constexpr int NATIVE_WRAP_FIELDS_OFFSET =
+    static_cast<int>(sizeof(node::ObjectWrap));
+
+// V8 JSMap layout: kTableOffset within the JSMap object holds a tagged
+// pointer to the backing OrderedHashMap table. Not exposed in V8's
+// public headers; kept in sync with
+// deps/v8/src/objects/js-collection.h (JSCollection::kTableOffset)
+// and the torque-generated JSCollection layout.
+constexpr int JS_MAP_TABLE_OFFSET = 0x18;
+
+// V8 OrderedHashMap layout: the on-heap table starts with a 16-byte
+// header before the element_count / deleted_element_count /
+// number_of_buckets fields. Not exposed in V8's public headers; kept in
+// sync with deps/v8/src/objects/ordered-hash-table.h
+// (OrderedHashTable base layout).
+constexpr int ORDERED_HASH_MAP_HEADER_SIZE = 0x10;
+
 NODE_MODULE_INIT() {
   CtxWrap::Init(exports);
   NODE_SET_METHOD(exports, "storeAls", StoreAls);
   NODE_SET_METHOD(exports, "getStoredAlsHash", GetStoredAlsHash);
 
   Isolate* isolate = Isolate::GetCurrent();
-  exports
-      ->Set(context,
-            String::NewFromUtf8Literal(isolate, "wrappedObjectOffset"),
-            Integer::New(isolate, WRAPPED_OBJECT_OFFSET))
-      .FromJust();
-  exports
-      ->Set(context,
-            String::NewFromUtf8Literal(isolate, "taggedSize"),
-            Integer::New(isolate, TAGGED_SIZE))
-      .FromJust();
+  auto publish_int = [&](const char* name, int value) {
+    exports
+        ->Set(context,
+              String::NewFromUtf8(isolate, name).ToLocalChecked(),
+              Integer::New(isolate, value))
+        .FromJust();
+  };
+  publish_int("jsMapTableOffset", JS_MAP_TABLE_OFFSET);
+  publish_int("nativeWrapFieldsOffset", NATIVE_WRAP_FIELDS_OFFSET);
+  publish_int("orderedHashMapHeaderSize", ORDERED_HASH_MAP_HEADER_SIZE);
+  publish_int("taggedSize", TAGGED_SIZE);
+  publish_int("wrappedObjectOffset", WRAPPED_OBJECT_OFFSET);
 }
 
 #pragma GCC diagnostic pop

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -27,6 +27,31 @@ export interface ProcessContextAttributes {
      * and OrderedHashMap-header offsets it walks without hardcoding them.
      */
     readonly 'threadlocal.tagged_size': number;
+
+    /**
+     * `sizeof(node::ObjectWrap)`. Given a pointer to a CtxWrap fetched via
+     * `wrapped_object_offset`, the reader adds this to reach the derived
+     * class's own fields — for CtxWrap, the `record_` pointer sits at
+     * exactly this offset.
+     */
+    readonly 'threadlocal.native_wrap_fields_offset': number;
+
+    /**
+     * Offset within a V8 `JSMap` object of the tagged pointer to its
+     * backing `OrderedHashMap` table (`JSCollection::kTableOffset` in V8).
+     * Not exposed in V8's public headers; the addon carries a build-time
+     * constant kept in sync with Node's private V8 tree.
+     */
+    readonly 'threadlocal.js_map_table_offset': number;
+
+    /**
+     * Size of the header preceding the `element_count` /
+     * `deleted_element_count` / `number_of_buckets` fields inside a V8
+     * `OrderedHashMap`. Not exposed in V8's public headers; the addon
+     * carries a build-time constant kept in sync with Node's private V8
+     * tree.
+     */
+    readonly 'threadlocal.ordered_hash_map_header_size': number;
 }
 
 /**

--- a/js/index.js
+++ b/js/index.js
@@ -9,6 +9,9 @@ const SCHEMA_VERSION = 'nodejs_v1_dev';
 // see consistent values.
 let WRAPPED_OBJECT_OFFSET = 24;
 let TAGGED_SIZE = 8;
+let NATIVE_WRAP_FIELDS_OFFSET = 24;
+let JS_MAP_TABLE_OFFSET = 0x18;
+let ORDERED_HASH_MAP_HEADER_SIZE = 0x10;
 
 // Public surface, populated by the Linux branch below. On other
 // platforms these stay as no-op stubs / a sham class.
@@ -21,6 +24,9 @@ if (process.platform === 'linux') {
     const addon = bindings('customlabels');
     WRAPPED_OBJECT_OFFSET = addon.wrappedObjectOffset;
     TAGGED_SIZE = addon.taggedSize;
+    NATIVE_WRAP_FIELDS_OFFSET = addon.nativeWrapFieldsOffset;
+    JS_MAP_TABLE_OFFSET = addon.jsMapTableOffset;
+    ORDERED_HASH_MAP_HEADER_SIZE = addon.orderedHashMapHeaderSize;
 
     ThreadContext = addon.ThreadContext;
 
@@ -135,6 +141,9 @@ function getProcessContextAttributes(keys) {
         'threadlocal.attribute_key_map': Object.freeze(keys.slice()),
         'threadlocal.wrapped_object_offset': WRAPPED_OBJECT_OFFSET,
         'threadlocal.tagged_size': TAGGED_SIZE,
+        'threadlocal.native_wrap_fields_offset': NATIVE_WRAP_FIELDS_OFFSET,
+        'threadlocal.js_map_table_offset': JS_MAP_TABLE_OFFSET,
+        'threadlocal.ordered_hash_map_header_size': ORDERED_HASH_MAP_HEADER_SIZE,
     });
 }
 

--- a/js/test/test.js
+++ b/js/test/test.js
@@ -359,8 +359,14 @@ test('getProcessContextAttributes returns the expected shape', () => {
     // compression, no sandbox) these are 24 and 8 respectively.
     assert.equal(pca['threadlocal.wrapped_object_offset'], 24);
     assert.equal(pca['threadlocal.tagged_size'], 8);
+    assert.equal(pca['threadlocal.native_wrap_fields_offset'], 24);
+    assert.equal(pca['threadlocal.js_map_table_offset'], 0x18);
+    assert.equal(pca['threadlocal.ordered_hash_map_header_size'], 0x10);
     assert.deepEqual(Object.keys(pca).sort(), [
         'threadlocal.attribute_key_map',
+        'threadlocal.js_map_table_offset',
+        'threadlocal.native_wrap_fields_offset',
+        'threadlocal.ordered_hash_map_header_size',
         'threadlocal.schema_version',
         'threadlocal.tagged_size',
         'threadlocal.wrapped_object_offset',


### PR DESCRIPTION
## Summary

Extends the OTEP-4719 process-context attributes returned by `getProcessContextAttributes` with three new keys an out-of-process eBPF reader needs to walk from our TLS discovery struct all the way to the OTEP-4947 record:

- `threadlocal.native_wrap_fields_offset` — `sizeof(node::ObjectWrap)`. Given a `CtxWrap*` fetched via `wrapped_object_offset`, add this to reach `CtxWrap::record_`.
- `threadlocal.js_map_table_offset` — offset within a V8 `JSMap` of the tagged pointer to its backing `OrderedHashMap` (0x18).
- `threadlocal.ordered_hash_map_header_size` — size of the header preceding the `element_count` / `deleted_element_count` / `n_buckets` fields inside an `OrderedHashMap` (0x10).

Without these a reader would have to hardcode them and re-verify per V8 version. Keeping them in the addon puts one source of truth close to V8. The two V8 internal offsets aren't exposed in V8's public headers; the code comments cite the Node.js private V8 source paths (`deps/v8/src/objects/{js-collection,ordered-hash-table}.h`) so a future V8 layout change has a clear pointer to what to re-check.

Motivated by planning an eBPF Node.js schema reader on top of open-telemetry/opentelemetry-ebpf-profiler#1229; the parca-dev fork already has a similar walker that hardcodes these values in eBPF (`native_custom_labels.h:304`).

Also folds the repeated `exports->Set(...).FromJust()` publication pattern in `NODE_MODULE_INIT` into a `publish_int` lambda, with calls sorted alphabetically by exported name.

## Test plan

- [x] Docker test suite (`./test/run-in-docker.sh`) — 45 passing, no regressions.
- [x] The `getProcessContextAttributes returns the expected shape` test now asserts the three new keys are present with expected values and updates the sorted-keys list.
